### PR TITLE
fix: strip leading 'v' prefix from version strings to prevent double-v display

### DIFF
--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -84,7 +84,8 @@ function parseGitDescribe(describe) {
 function calculateMinVer() {
   // Allow override via environment (for Docker/CI)
   if (process.env.VERSION) {
-    return process.env.VERSION;
+    // Strip leading "v" if present — callers add their own prefix
+    return process.env.VERSION.replace(/^v/i, "");
   }
   try {
     const result = spawnSync("git", ["describe", "--tags", "--long", "--always", "--dirty"], {

--- a/src/agent/version.ts
+++ b/src/agent/version.ts
@@ -95,7 +95,8 @@ export function getVersion(): string {
 
   // Check for build-time injected version
   if (typeof __HYPERAGENT_VERSION__ !== "undefined") {
-    cachedVersion = __HYPERAGENT_VERSION__;
+    // Strip leading "v" if present — callers add their own prefix
+    cachedVersion = __HYPERAGENT_VERSION__.replace(/^v/i, "");
     return cachedVersion;
   }
 

--- a/src/plugin-system/manager.ts
+++ b/src/plugin-system/manager.ts
@@ -209,6 +209,16 @@ export function validateManifest(raw: unknown): string[] {
   if ("version" in obj && typeof obj.version !== "string") {
     errors.push("version must be a string");
   }
+  if (
+    "version" in obj &&
+    typeof obj.version === "string" &&
+    /^v/i.test(obj.version)
+  ) {
+    // Callers prepend "v" for display — a prefixed version causes "vv1.0.0"
+    errors.push(
+      'version must not start with "v" (use bare semver, e.g. "1.0.0")',
+    );
+  }
   if ("description" in obj && typeof obj.description !== "string") {
     errors.push("description must be a string");
   }

--- a/src/plugin-system/types.ts
+++ b/src/plugin-system/types.ts
@@ -61,7 +61,7 @@ export interface ConfigSchemaEntry {
 export interface PluginManifest {
   /** Unique plugin name (kebab-case, matches directory name). */
   name: string;
-  /** SemVer version string. */
+  /** SemVer version string (bare, no "v" prefix — e.g. "1.0.0" not "v1.0.0"). */
   version: string;
   /** One-line description of what the plugin does. */
   description: string;

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -82,6 +82,19 @@ describe("validateManifest", () => {
     expect(errors).toContain("hostModules must be an array");
   });
 
+  it('should reject version with "v" prefix', () => {
+    const manifest = {
+      name: "test",
+      version: "v1.0.0",
+      description: "Test",
+      hostModules: ["fs"],
+    };
+    const errors = validateManifest(manifest);
+    expect(errors).toContain(
+      'version must not start with "v" (use bare semver, e.g. "1.0.0")',
+    );
+  });
+
   it("should reject empty hostModules array", () => {
     const manifest = {
       name: "test",


### PR DESCRIPTION
VERSION env var and __HYPERAGENT_VERSION__ build-time injection could include a 'v' prefix (e.g. from git tags like 'v0.1.0'). Since callers already prepend 'v' for display, this caused 'vv0.1.0' in the banner.

- Strip leading 'v' from process.env.VERSION in build-binary.js
- Strip leading 'v' from __HYPERAGENT_VERSION__ in version.ts
- Reject plugin manifest versions with 'v' prefix in validator
- Add test for version prefix validation