### PR TITLE
fix: skip postinstall/prepare scripts when installed as npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "fmt": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" \"plugins/**/*.ts\" \"builtin-modules/**/*.js\"",
     "fmt:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\" \"plugins/**/*.ts\" \"builtin-modules/**/*.js\"",
     "check": "npm run fmt:check && npm run typecheck && npm run test",
-    "prepare": "npm run build:modules",
-    "postinstall": "node scripts/patch-vscode-jsonrpc.js && node scripts/check-native-runtime.js"
+    "prepare": "[ ! -f scripts/build-modules.js ] || npm run build:modules",
+    "postinstall": "[ ! -f scripts/patch-vscode-jsonrpc.js ] || (node scripts/patch-vscode-jsonrpc.js && node scripts/check-native-runtime.js)"
   },
   "dependencies": {
     "@github/copilot-sdk": "^0.1.32",


### PR DESCRIPTION
The postinstall and prepare hooks reference scripts in scripts/ which are not included in the published npm package (files: ['dist/'] only). This caused 'npm install -g @hyperlight-dev/hyperagent' to fail with MODULE_NOT_FOUND.

Use '[ ! -f script ] || command' pattern so hooks skip gracefully when scripts don't exist (published package) but still fail loudly when they do exist and error (dev context).