### PR TITLE
chore: publish npm package to npmjs.org instead of GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
 
   # Build and publish npm package (after tests pass)
   publish-npm:
-    name: Publish to GitHub Packages (npm)
+    name: Publish to npmjs.org
     needs: [test]
     runs-on: ubuntu-latest
     steps:
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: "https://registry.npmjs.org"
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.8.0
         with:
@@ -92,10 +92,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 
-      - name: Publish to GitHub Packages
-        run: npm publish
+      - name: Publish to npmjs.org
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Build and publish Docker image (after tests pass)
   publish-docker:

--- a/README.md
+++ b/README.md
@@ -109,9 +109,6 @@ docker run -it --rm `
 ### Option 2: npm package
 
 ```bash
-# Configure npm for GitHub Packages
-npm config set @hyperlight-dev:registry https://npm.pkg.github.com
-
 # Install globally
 npm install -g @hyperlight-dev/hyperagent
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,7 +50,7 @@ git push origin v0.1.1
 The [publish workflow](../.github/workflows/publish.yml) automatically:
 
 1. Runs tests on all hypervisors (KVM, MSHV, WHP)
-2. Publishes npm package to GitHub Packages (`@hyperlight-dev/hyperagent`)
+2. Publishes npm package to [npmjs.org](https://www.npmjs.com/package/@hyperlight-dev/hyperagent)
 3. Publishes Docker image to GitHub Container Registry (`ghcr.io/hyperlight-dev/hyperagent`)
 
 ## Manual Release (workflow_dispatch)
@@ -66,9 +66,6 @@ For testing or hotfixes without creating a git tag:
 ### npm package
 
 ```bash
-# Configure npm for GitHub Packages
-npm config set @hyperlight-dev:registry https://npm.pkg.github.com
-
 # Install specific version
 npm install @hyperlight-dev/hyperagent@0.1.0
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dist/"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Switch from GitHub Packages (npm.pkg.github.com) to the public npm registry (registry.npmjs.org) so users can install without configuring a custom registry.

- Update publishConfig in package.json to npmjs.org with public access
- Update publish workflow to use registry.npmjs.org and NPM_TOKEN secret
- Remove GitHub Packages registry config from README install instructions
- Update RELEASING docs to reflect new publish target

Requires NPM_TOKEN repository secret with npmjs.org publish permissions.