### PR TITLE
fix: resolve symlinks in launcher script for npm global install

### DIFF
--- a/scripts/build-binary.js
+++ b/scripts/build-binary.js
@@ -318,7 +318,13 @@ console.log("📝 Creating launcher...");
 // We use a shell wrapper that invokes node with explicit CommonJS treatment
 const launcher = `#!/bin/sh
 # HyperAgent Launcher - resolves native addons from lib/ directory
-exec node --no-warnings "\${0%/*}/../lib/hyperagent-launcher.cjs" "$@"
+# When invoked via PATH, $0 may be a bare name (no slash). Resolve it first.
+SELF="$0"
+case "$SELF" in */*) ;; *) SELF="$(command -v -- "$SELF")" ;; esac
+# Resolve symlinks so this works when npm links the bin globally
+SELF="$(readlink -f "$SELF" 2>/dev/null || realpath "$SELF" 2>/dev/null || echo "$SELF")"
+SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+exec node --no-warnings "\${SCRIPT_DIR}/../lib/hyperagent-launcher.cjs" "$@"
 `;
 
 // The actual launcher logic in CommonJS


### PR DESCRIPTION
The shell launcher used ${0%/*} to find its lib/ directory, but when npm installs globally it creates a symlink in the bin dir. ${0%/*} resolves to the npm bin dir, not the package dir, causing:
  Cannot find module '.../lib/hyperagent-launcher.cjs'

Use readlink -f / realpath to resolve symlinks before computing the relative path to the lib directory.

Tested: symlink from /tmp/ → prints version correctly; old approach confirmed to fail with MODULE_NOT_FOUND.