### PR TITLE
docs: add v0.1.3 changelog and skip CI for docs-only PRs

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -14,11 +14,36 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  # Skip heavy CI when only docs change (README, CHANGELOG, docs/, etc.)
+  # Note: skills/**/*.md and patterns/**/*.md are runtime content with
+  # integrity tests — they must NOT be skipped.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - 'skills/**'
+              - 'patterns/**'
+
   # Lint, typecheck, and unit tests (needs KVM for sandbox tests)
   lint-and-test:
     name: Lint & Test
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
     steps:
       - uses: actions/checkout@v6
@@ -48,6 +73,8 @@ jobs:
   # See: https://github.com/hyperlight-dev/hyperagent/issues/1
   build-and-test:
     name: Build & Test (${{ matrix.hypervisor }}-${{ matrix.config }})
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +134,8 @@ jobs:
   # Build Docker image (just setup clones deps so Dockerfile COPY works)
   build-docker:
     name: Build Docker Image
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -141,7 +170,7 @@ jobs:
   # Gate PR merges on all jobs passing
   ci-status:
     name: CI Status
-    needs: [lint-and-test, build-and-test, build-docker]
+    needs: [changes, lint-and-test, build-and-test, build-docker]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.3] - 2026-03-24
+
+### Fixed
+
+- **Plugin loading under npm** — Plugins failed with "Stripping types is currently unsupported for files under node_modules" when installed via npm. Plugin loader now prefers compiled `.js` over `.ts` when running under `node_modules`, while still using `.ts` in dev mode for live editing
+- **Plugin hash/approval consistency** — `computePluginHash()`, `loadSource()`, and `verifySourceHash()` now use centralised `resolvePluginSource()` helper to ensure hashing and import use the same file
+
 ## [v0.1.2] - 2026-03-23
 
 ### Fixed
@@ -91,6 +98,7 @@ Initial public release.
 - Path jailing for filesystem plugins
 - SSRF protection for fetch plugin (DNS + post-connect IP validation)
 
+[v0.1.3]: https://github.com/hyperlight-dev/hyperagent/releases/tag/v0.1.3
 [v0.1.2]: https://github.com/hyperlight-dev/hyperagent/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/hyperlight-dev/hyperagent/releases/tag/v0.1.1
 [v0.1.0]: https://github.com/hyperlight-dev/hyperagent/releases/tag/v0.1.0


### PR DESCRIPTION
- Add v0.1.3 changelog entry for plugin .ts/.js loading fix
- Skip lint, build, and test jobs when only docs change
- Uses dorny/paths-filter to detect code vs docs-only changes