### PR TITLE
fix: add missing checkout step to docs-pr CI job

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       docs-only: ${{ steps.docs-only.outputs.result }}
     steps:
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: changes
         with:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -24,6 +24,8 @@ jobs:
       docs-only: ${{ steps.docs-only.outputs.result }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: changes
         with:


### PR DESCRIPTION
dorny/paths-filter needs a git checkout to run git diff. The checkout step was accidentally removed when rewriting the docs-only skip logic.