### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,26 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
-updates: 
+updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
       time: "03:00"
+    open-pull-requests-limit: 20
+
   - package-ecosystem: "cargo"
-    directories: 
-      - "/"
+    directories:
+      - "/src/sandbox/runtime"
+      - "/src/code-validator/guest"
     schedule:
       interval: "daily"
       time: "03:00"
+    open-pull-requests-limit: 20
+
   - package-ecosystem: "npm"
-    directory: "/src/js-host-api"
+    directories:
+      - "/"
+      - "/src/code-validator/guest"
     schedule:
       interval: "daily"
       time: "03:00"
+    open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,6 @@ updates:
       interval: "daily"
       time: "03:00"
     open-pull-requests-limit: 20
+    ignore:
+      # Build-time symlink to external Cargo checkout — not in the repo
+      - dependency-name: "@hyperlight/js-host-api"


### PR DESCRIPTION
This pull request updates the Dependabot to exclude hyperlight-dev/js-host-api as this is not yet published with all the changes hyperagent needs
