### PR TITLE
fix: align code-validator hyperlight deps with hyperlight-js

### DIFF
--- a/src/code-validator/guest/Cargo.toml
+++ b/src/code-validator/guest/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 repository = "https://github.com/anthropics/hyperagent"
 
 [workspace.dependencies]
-# Hyperlight dependencies - aligned with deps/hyperlight-js
+# Hyperlight dependencies - aligned with the hyperlight-js runtime resolved via Cargo git checkout
 hyperlight-common = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate", default-features = false }
 hyperlight-guest-bin = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate" }
 hyperlight-guest = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate" }

--- a/src/code-validator/guest/Cargo.toml
+++ b/src/code-validator/guest/Cargo.toml
@@ -17,11 +17,11 @@ license = "Apache-2.0"
 repository = "https://github.com/anthropics/hyperagent"
 
 [workspace.dependencies]
-# Hyperlight dependencies - pinned to same revision as hyperlight-js
-hyperlight-common = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "620339aa95d508e8cbd1d38b4374f09090aade7b", default-features = false }
-hyperlight-guest-bin = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "620339aa95d508e8cbd1d38b4374f09090aade7b" }
-hyperlight-guest = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "620339aa95d508e8cbd1d38b4374f09090aade7b" }
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", rev = "620339aa95d508e8cbd1d38b4374f09090aade7b", default-features = false, features = ["executable_heap", "init-paging", "kvm", "mshv3"] }
+# Hyperlight dependencies - aligned with deps/hyperlight-js
+hyperlight-common = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate", default-features = false }
+hyperlight-guest-bin = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate" }
+hyperlight-guest = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate" }
+hyperlight-host = { git = "https://github.com/simongdavies/hyperlight", branch = "update-surrogate", default-features = false, features = ["executable_heap", "kvm", "mshv3"] }
 
 [profile.dev]
 panic = "abort"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,9 +12,12 @@ export default defineConfig({
     // On Windows, two SurrogateProcessManagers each pre-create a pool of
     // surrogate processes. Keep the initial pool small — on-demand growth
     // up to the default 512 max handles spikes without wasting resources.
-    env: {
-      HYPERLIGHT_INITIAL_SURROGATES: "4",
-    },
+    env:
+      process.platform === "win32"
+        ? {
+            HYPERLIGHT_INITIAL_SURROGATES: "4",
+          }
+        : {},
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     // Exclude compiled build artefacts and dependency clones
     exclude: ["dist/**", "node_modules/**", "deps/**"],
+    // On Windows, two SurrogateProcessManagers each pre-create a pool of
+    // surrogate processes. Keep the initial pool small — on-demand growth
+    // up to the default 512 max handles spikes without wasting resources.
+    env: {
+      HYPERLIGHT_INITIAL_SURROGATES: "4",
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Switch code-validator/guest from hyperlight-dev/hyperlight@620339a to simongdavies/hyperlight branch update-surrogate, matching deps/hyperlight-js
- Drop removed 'init-paging' feature (absorbed into default in v0.13.1)
- Add HYPERLIGHT_INITIAL_SURROGATES=4 to vitest.config.ts to avoid eagerly spawning 512 surrogate processes during tests

Fixes SurrogateProcessManager creation failure on Windows.