### PR TITLE
fix npm install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,8 +188,16 @@ jobs:
 
       # Trusted publishing requires npm >=11.5.1 for OIDC token exchange.
       # Pin to ^11.5.1 so we don't silently get an older 11.x that lacks OIDC.
+      #
+      # Bootstrap via `npx` rather than `npm install -g npm@...` — the latter
+      # hits a long-standing npm self-upgrade bug (reproduces on github-hosted
+      # runners too) where mid-reify npm unlinks its own `promise-retry` dep
+      # and dies with MODULE_NOT_FOUND. Using a fresh npx-fetched npm to
+      # install itself globally sidesteps the half-upgraded state entirely.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@^11.5.1 && npm --version
+        run: |
+          npx --yes npm@^11.5.1 install -g --force npm@^11.5.1
+          npm --version
 
       - name: Download npm tarball
         uses: actions/download-artifact@v8


### PR DESCRIPTION
This pull request updates the npm upgrade step in the GitHub Actions workflow to address a known issue with npm self-upgrades. Instead of using `npm install -g npm@...`, the workflow now uses `npx` to bootstrap the upgrade process, which avoids a bug that can cause the upgrade to fail.
