### PR TITLE
feat: /plugins as alias for /plugin

### DIFF
--- a/src/agent/commands.ts
+++ b/src/agent/commands.ts
@@ -483,9 +483,17 @@ const COMMANDS: readonly CommandEntry[] = Object.freeze([
 ]);
 
 /** Pre-computed completion strings for the readline completer. */
-export const COMPLETION_STRINGS: readonly string[] = COMMANDS.map(
-  (c) => c.completion,
-);
+export const COMPLETION_STRINGS: readonly string[] = [
+  ...COMMANDS.map((c) => c.completion),
+  // Aliases — /plugins is shorthand for /plugin
+  "/plugins list",
+  "/plugins info ",
+  "/plugins enable ",
+  "/plugins disable ",
+  "/plugins approve ",
+  "/plugins unapprove ",
+  "/plugins audit ",
+];
 
 /**
  * Render the full help text from the COMMANDS registry.

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -806,7 +806,9 @@ export async function handleSlashCommand(
     // ── Plugin Commands ──────────────────────────────────────
     //
     // All plugin operations live under /plugin <sub>.
+    // /plugins is an alias for /plugin.
 
+    case "/plugins":
     case "/plugin": {
       const subCmd = parts[1]?.toLowerCase();
       // Plugin name sits at parts[2], args at parts[3]+.


### PR DESCRIPTION
This pull request enhances the handling and user experience of plugin-related slash commands. The main improvements are the addition of `/plugins` as an alias for `/plugin`, and the expansion of command completion strings to include common `/plugins` subcommands.

**Plugin command improvements:**

* Added `/plugins` as an alias for `/plugin` in the slash command handler, allowing users to use either form interchangeably.

**Command completion enhancements:**

* Expanded the `COMPLETION_STRINGS` array in `src/agent/commands.ts` to include `/plugins` subcommands (e.g., `/plugins list`, `/plugins info`, etc.), improving command auto-completion and discoverability for users.Both /plugin and /plugins now work identically. Tab completion includes both forms.