### PR TITLE
fix: native module resolution breaks validation loop for ha:pdf

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1226,7 +1226,7 @@ async function validateHandlerCode(
       Object.keys(newDtsSources).length === 0
     ) {
       // No new sources, module metadata, or type definitions found.
-      // Check if any specifiers are bare (no ha:/host: prefix).
+      // Check if any specifiers are missing a ha: or host: prefix.
       const unresolvable = validation.missingSources.filter(
         (s) => !s.startsWith("ha:") && !s.startsWith("host:"),
       );

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1220,7 +1220,13 @@ async function validateHandlerCode(
       moduleJsons: newModuleJsons,
     } = loadModuleFilesForValidator(validation.missingSources, pluginManager);
 
-    if (Object.keys(newSources).length === 0) {
+    if (
+      Object.keys(newSources).length === 0 &&
+      Object.keys(newModuleJsons).length === 0 &&
+      Object.keys(newDtsSources).length === 0
+    ) {
+      // No new sources, module metadata, or type definitions found.
+      // Check if any specifiers are bare (no ha:/host: prefix).
       const unresolvable = validation.missingSources.filter(
         (s) => !s.startsWith("ha:") && !s.startsWith("host:"),
       );
@@ -1401,7 +1407,12 @@ const registerHandlerTool = defineTool("register_handler", {
 
         // If we couldn't resolve ANY of the missing sources, generate helpful errors
         // This happens when imports use wrong prefixes (e.g., "pptx" instead of "ha:pptx")
-        if (Object.keys(newSources).length === 0) {
+        // Native modules have module.json but no .js source — check all three.
+        if (
+          Object.keys(newSources).length === 0 &&
+          Object.keys(newModuleJsons).length === 0 &&
+          Object.keys(newDtsSources).length === 0
+        ) {
           const unresolvable = validation.missingSources.filter(
             (s) => !s.startsWith("ha:") && !s.startsWith("host:"),
           );


### PR DESCRIPTION
The module resolution loop checked only Object.keys(newSources) to decide whether to continue resolving. Native modules (like ha:ziplib) have no .js source — only module.json metadata — so the loop broke early with valid=false and an empty errors array, producing the cryptic 'Validation failed: •' message.

Root cause: ha:pdf imports ha:ziplib (native). The resolution loop loaded ziplib.json but not ziplib.js (doesn't exist). Since newSources was empty, it broke out of the loop before passing the JSON metadata to the validator. The validator then couldn't confirm ziplib was resolved, returning valid=false with no errors.

Fix: check all three sources (newSources, newModuleJsons, newDtsSources) before deciding nothing was found. This allows native module metadata to flow through and lets the validator recognise them as resolved.

Applied to both register_handler and register_module validation loops.