### PR TITLE
Feat markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,5 @@ plugins/shared/*.js
 plugins/plugin-schema-types.d.ts
 plugins/plugin-schema-types.js
 plugins/host-modules.d.ts
-output-hyperagent**/**scripts/bash-bundle/_tmp_bundle.js
 output-hyperagent-*/
 scripts/bash-bundle/_tmp_bundle.js

--- a/builtin-modules/bash.json
+++ b/builtin-modules/bash.json
@@ -4,7 +4,7 @@
   "author": "system",
   "mutable": false,
   "type": "script",
-  "sourceHash": "sha256:31219cbf85cf26d1",
+  "sourceHash": "sha256:a86d1d576100eb10",
   "hints": {
     "overview": "Pure-JS bash interpreter for the sandbox. Used internally by the execute_bash tool — not intended for direct import in handlers."
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,15 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "boxen": "^8.0.1",
         "hyperlight-analysis": "file:src/code-validator/guest",
+        "marked": "^15.0.12",
+        "marked-terminal": "^7.3.0",
         "zod": "^4.3.6"
       },
       "bin": {
         "hyperagent": "dist/bin/hyperagent"
       },
       "devDependencies": {
+        "@types/marked-terminal": "^6.1.1",
         "@types/node": "^25.3.3",
         "@types/pngjs": "^6.0.5",
         "@xarsh/ooxml-validator": "^0.1.10",
@@ -67,21 +70,21 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.1.tgz",
-      "integrity": "sha512-VxKdEtUwDuLD0F1hOQP7kye0YadZxFJfv37Em440geEf/w9uggKnHpRrqwZJOdxmPUOdhZ9kyRtKuAJW8wUcRg==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.2.tgz",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.1.tgz",
-      "integrity": "sha512-tmQiQ2HvtzaeLqYGy3BemiPOSGPY4wCy1IW5zDWITKSs/s35WEd7Zij/hCxvUdAOzj6U3qnyaGbYXY91ortFEQ==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.5.tgz",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.6.1",
+        "@azure/msal-common": "16.5.2",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -99,10 +102,20 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -112,7 +125,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1962,9 +1977,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1972,9 +1987,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1989,9 +2004,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -2006,9 +2021,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -2023,9 +2038,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -2040,9 +2055,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -2057,9 +2072,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -2074,9 +2089,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -2091,9 +2106,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -2108,9 +2123,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -2125,9 +2140,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -2142,9 +2157,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -2159,9 +2174,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -2176,9 +2191,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -2186,8 +2201,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
@@ -2195,9 +2210,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -2212,9 +2227,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -2229,11 +2244,23 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2268,15 +2295,22 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2311,14 +2345,38 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+    "node_modules/@types/marked-terminal": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/marked-terminal/-/marked-terminal-6.1.1.tgz",
+      "integrity": "sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "@types/cardinal": "^2.1",
+        "@types/node": "*",
+        "chalk": "^5.3.0",
+        "marked": ">=6.0.0 <12"
+      }
+    },
+    "node_modules/@types/marked-terminal/node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/pngjs": {
@@ -2330,16 +2388,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2348,13 +2406,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2375,9 +2433,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2388,13 +2446,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2402,14 +2460,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2418,9 +2476,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2428,13 +2486,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2580,6 +2638,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "license": "MIT",
@@ -2599,6 +2672,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2818,6 +2897,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "dev": true,
@@ -2841,6 +2929,114 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "dev": true,
@@ -2862,6 +3058,108 @@
       "peerDependencies": {
         "typanion": "*"
       }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3077,6 +3375,12 @@
       "version": "10.6.0",
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -3095,6 +3399,18 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -3181,6 +3497,15 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3540,9 +3865,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -3553,9 +3878,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3712,6 +4038,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "license": "MIT",
@@ -3801,6 +4136,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3823,6 +4167,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hono": {
@@ -4447,6 +4800,39 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4571,10 +4957,21 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4635,6 +5032,21 @@
       "optional": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-gyp-build": {
@@ -4775,6 +5187,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4913,9 +5346,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5139,6 +5572,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5157,14 +5599,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5173,21 +5615,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/router": {
@@ -5459,6 +5901,18 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5595,6 +6049,34 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -5625,6 +6107,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -6300,11 +6803,18 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.19.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -6346,16 +6856,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -6372,7 +6882,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -6424,19 +6934,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6464,12 +6974,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6599,10 +7109,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6613,6 +7132,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -6650,7 +7237,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.6"
       },
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,12 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "boxen": "^8.0.1",
     "hyperlight-analysis": "file:src/code-validator/guest",
+    "marked": "^15.0.12",
+    "marked-terminal": "^7.3.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/marked-terminal": "^6.1.1",
     "@types/node": "^25.3.3",
     "@types/pngjs": "^6.0.5",
     "@xarsh/ooxml-validator": "^0.1.10",

--- a/scripts/bash-bundle/build.mjs
+++ b/scripts/bash-bundle/build.mjs
@@ -33,6 +33,7 @@ if (!existsSync(join(repoRoot, "node_modules", "just-bash"))) {
 }
 
 const aliasArgs = [
+  `--alias:node:module=${join(stubDir, "module-stub.mjs")}`,
   `--alias:node:zlib=${join(stubDir, "zlib-stub.mjs")}`,
   `--alias:node:worker_threads=${join(stubDir, "worker-stub.mjs")}`,
   `--alias:node:path=${join(stubDir, "node-path-stub.mjs")}`,

--- a/scripts/bash-bundle/module-stub.mjs
+++ b/scripts/bash-bundle/module-stub.mjs
@@ -1,0 +1,9 @@
+// Stub for node:module — used by just-bash for createRequire()
+// In the Hyperlight sandbox there's no native require(); return a
+// function that throws so callers fall back to ESM imports.
+export function createRequire() {
+  return function fakeRequire(id) {
+    throw new Error("require() not available in sandbox: " + id);
+  };
+}
+export default { createRequire };

--- a/scripts/build-modules.js
+++ b/scripts/build-modules.js
@@ -87,8 +87,13 @@ try {
     });
   }
 } catch (e) {
-  console.error("  \u26a0\ufe0f  bash bundle build failed:", e.message);
-  // Non-fatal — bash is optional, core agent works without it
+  if (process.env.CI) {
+    // Fail hard in CI — stale bash bundles must not slip through
+    console.error("  ❌  bash bundle build failed (fatal in CI):", e.message);
+    process.exit(1);
+  }
+  console.error("  ⚠️  bash bundle build failed:", e.message);
+  // Non-fatal locally — bash is optional, core agent works without it
 }
 
 // Step 5b: Auto-update hashes in .json metadata files

--- a/src/agent/ansi.ts
+++ b/src/agent/ansi.ts
@@ -48,4 +48,21 @@ export const C = {
     on ? `${ANSI.green}ON${ANSI.reset}` : `${ANSI.red}OFF${ANSI.reset}`,
   /** Dim italic — model reasoning text (ephemeral inner monologue). */
   reasoning: (s: string) => `${ANSI.dim}${ANSI.italic}${s}${ANSI.reset}`,
+  /**
+   * OSC 8 terminal hyperlink — makes `label` clickable, opening `uri`.
+   * Falls back to plain underlined cyan text if the terminal doesn't
+   * support OSC 8 (the escape is harmless in those terminals).
+   *
+   * Usage: C.link('https://example.com', 'click here')
+   */
+  link: (uri: string, label?: string) =>
+    `\x1b]8;;${uri}\x07${ANSI.underline}${ANSI.cyan}${label ?? uri}${ANSI.reset}\x1b]8;;\x07`,
+  /**
+   * Format a file path for terminal output.
+   * Outputs the raw absolute path with NO ANSI styling so that
+   * terminal emulators (VS Code, Windows Terminal, iTerm2) can
+   * auto-detect it and make it ctrl-clickable natively.
+   * Adding ANSI escapes breaks the terminal's path detection regex.
+   */
+  fileLink: (absPath: string, _label?: string) => absPath,
 } as const;

--- a/src/agent/cli-parser.ts
+++ b/src/agent/cli-parser.ts
@@ -104,7 +104,7 @@ Options:
   --show-timing          Log timing breakdown to ~/.hyperagent/logs/
   --show-reasoning [level] Set reasoning effort (low|medium|high|xhigh, default: high)
   --verbose              Verbose output mode (scrolling reasoning, turn details)
-  --markdown             Render LLM output as formatted markdown (disables streaming)
+  --no-markdown          Disable markdown rendering (use raw streaming instead)
   --transcript           Record session transcript to ~/.hyperagent/logs/
   --list-models          List available models and exit
   --resume [id]          Resume previous session (last if no ID given)
@@ -180,7 +180,7 @@ export function parseCliArgs(
     showTiming: false,
     showReasoning: process.env.HYPERAGENT_SHOW_REASONING || "",
     verbose: process.env.HYPERAGENT_VERBOSE === "1",
-    markdown: process.env.HYPERAGENT_MARKDOWN === "1",
+    markdown: process.env.HYPERAGENT_MARKDOWN !== "0",
     transcript: process.env.HYPERAGENT_TRANSCRIPT === "1",
     listModels: process.env.HYPERAGENT_LIST_MODELS === "1",
     resumeSession: process.env.HYPERAGENT_RESUME_SESSION || "",
@@ -264,6 +264,10 @@ export function parseCliArgs(
       }
       case "--verbose":
         config.verbose = true;
+        break;
+      case "--no-markdown":
+      case "--no-md":
+        config.markdown = false;
         break;
       case "--markdown":
       case "--md":

--- a/src/agent/cli-parser.ts
+++ b/src/agent/cli-parser.ts
@@ -21,6 +21,8 @@ export interface CliConfig {
   showTiming: boolean;
   showReasoning: string;
   verbose: boolean;
+  /** Render LLM markdown output with ANSI formatting (headings, code, lists). */
+  markdown: boolean;
   transcript: boolean;
   listModels: boolean;
   resumeSession: string;
@@ -102,6 +104,7 @@ Options:
   --show-timing          Log timing breakdown to ~/.hyperagent/logs/
   --show-reasoning [level] Set reasoning effort (low|medium|high|xhigh, default: high)
   --verbose              Verbose output mode (scrolling reasoning, turn details)
+  --markdown             Render LLM output as formatted markdown (disables streaming)
   --transcript           Record session transcript to ~/.hyperagent/logs/
   --list-models          List available models and exit
   --resume [id]          Resume previous session (last if no ID given)
@@ -177,6 +180,7 @@ export function parseCliArgs(
     showTiming: false,
     showReasoning: process.env.HYPERAGENT_SHOW_REASONING || "",
     verbose: process.env.HYPERAGENT_VERBOSE === "1",
+    markdown: process.env.HYPERAGENT_MARKDOWN === "1",
     transcript: process.env.HYPERAGENT_TRANSCRIPT === "1",
     listModels: process.env.HYPERAGENT_LIST_MODELS === "1",
     resumeSession: process.env.HYPERAGENT_RESUME_SESSION || "",
@@ -260,6 +264,10 @@ export function parseCliArgs(
       }
       case "--verbose":
         config.verbose = true;
+        break;
+      case "--markdown":
+      case "--md":
+        config.markdown = true;
         break;
       case "--transcript":
         config.transcript = true;

--- a/src/agent/commands.ts
+++ b/src/agent/commands.ts
@@ -110,6 +110,23 @@ const COMMANDS: readonly CommandEntry[] = Object.freeze([
       "\n" +
       "Also: --verbose CLI flag or HYPERAGENT_VERBOSE=1.",
   },
+  {
+    completion: "/markdown",
+    help: "Toggle markdown rendering for LLM output",
+    detail:
+      "Toggles terminal markdown rendering on/off.\n" +
+      "\n" +
+      "When ON:\n" +
+      "  • LLM output is buffered (not streamed character-by-character)\n" +
+      "  • Rendered with ANSI colours: headings, bold, code blocks, lists, tables\n" +
+      "  • Much more readable for structured responses\n" +
+      "\n" +
+      "When OFF (default):\n" +
+      "  • Raw text streamed in real-time (faster perceived response)\n" +
+      "  • Markdown syntax shown as-is (# headings, **bold**, ```code```)\n" +
+      "\n" +
+      "Also: --markdown CLI flag or HYPERAGENT_MARKDOWN=1.",
+  },
 
   // ── Timeouts & Buffers ───────────────────────────────────
   {

--- a/src/agent/commands.ts
+++ b/src/agent/commands.ts
@@ -116,12 +116,12 @@ const COMMANDS: readonly CommandEntry[] = Object.freeze([
     detail:
       "Toggles terminal markdown rendering on/off.\n" +
       "\n" +
-      "When ON:\n" +
+      "When ON (default):\n" +
       "  • LLM output is buffered (not streamed character-by-character)\n" +
       "  • Rendered with ANSI colours: headings, bold, code blocks, lists, tables\n" +
       "  • Much more readable for structured responses\n" +
       "\n" +
-      "When OFF (default):\n" +
+      "When OFF:\n" +
       "  • Raw text streamed in real-time (faster perceived response)\n" +
       "  • Markdown syntax shown as-is (# headings, **bold**, ```code```)\n" +
       "\n" +

--- a/src/agent/commands.ts
+++ b/src/agent/commands.ts
@@ -125,7 +125,7 @@ const COMMANDS: readonly CommandEntry[] = Object.freeze([
       "  • Raw text streamed in real-time (faster perceived response)\n" +
       "  • Markdown syntax shown as-is (# headings, **bold**, ```code```)\n" +
       "\n" +
-      "Also: --markdown CLI flag or HYPERAGENT_MARKDOWN=1.",
+      "Enabled by default. Disable: --no-markdown or HYPERAGENT_MARKDOWN=0.",
   },
 
   // ── Timeouts & Buffers ───────────────────────────────────
@@ -258,6 +258,23 @@ const COMMANDS: readonly CommandEntry[] = Object.freeze([
       "Omit the id to resume the most recent hyperagent session.\n" +
       "Pass a full or partial session ID (prefix optional).\n" +
       "Example: /resume abc123",
+  },
+  {
+    completion: "/files",
+    help: "List all files produced in this session",
+    detail:
+      "Shows numbered references for all files created during\n" +
+      "this session (via write_output, handlers, or auto-save).\n" +
+      "Use /open <n> to open a file by its number.",
+  },
+  {
+    completion: "/open",
+    help: "Open a produced file by number (/open <n>)",
+    detail:
+      "Opens a file from the /files list using the system default\n" +
+      "application. Works on WSL (converts to Windows path),\n" +
+      "macOS (open), and Linux (xdg-open).\n" +
+      "Example: /open 1",
   },
   {
     completion: "/history",

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -290,20 +290,13 @@ export function registerEventHandler(
       }
 
       case "tool.execution_start": {
-        // Tool is executing — swap the label to show which tool
+        // Tool is executing — show which tool the LLM picked
         const toolName = event.data?.toolName ?? "unknown";
         const callId = event.data?.toolCallId;
         if (callId) pendingTools.set(callId, toolName);
 
-        if (toolName === "execute_javascript") {
-          // Our sandbox tool — stop spinner, show explicit line
-          spinner.stop();
-          console.log(`\n  ${C.tool("🔧 Running code...")}`);
-        } else {
-          // SDK protocol tool — restart spinner with tool label.
-          // start() not updateLabel() — spinner may be stopped.
-          spinner.start(`Running ${toolName}...`);
-        }
+        spinner.stop();
+        console.log(`\n  ${C.tool(`🔧 ${toolName}`)}`);
         break;
       }
 
@@ -315,7 +308,9 @@ export function registerEventHandler(
         if (callId) pendingTools.delete(callId);
 
         // Skip noisy protocol tools in non-debug mode
-        if (toolName !== "execute_javascript") {
+        const isSandboxTool =
+          toolName === "execute_javascript" || toolName === "execute_bash";
+        if (!isSandboxTool) {
           if (state.debugEnabled) {
             const status = event.data?.success ? "✅" : "❌";
             debugLog(`${status} ${toolName} complete`);
@@ -323,90 +318,101 @@ export function registerEventHandler(
           break;
         }
 
-        // Show result summary for our sandbox tool
+        // Show result summary for our sandbox tools
         if (event.data?.success) {
-          const content = event.data?.result?.content ?? "";
-          let parsed;
-          try {
-            parsed = JSON.parse(content);
-          } catch {
-            // Not JSON — show raw
-          }
-
-          if (parsed?.error) {
-            // If _userDisplayed is set, the tool handler already
-            // printed the clean error — don't re-display it.
-            if (!parsed._userDisplayed) {
-              console.log(`  ${C.err("❌ " + parsed.error)}`);
-              suggestBufferIncreaseIfNeeded(parsed.error);
-            }
+          // In non-verbose mode, skip the result display —
+          // the LLM will summarise results for the user anyway.
+          if (!state.verboseOutput) {
+            // Brief confirmation so the user knows something happened
+            console.log(`  ${C.ok("✅ Done")}`);
           } else {
-            const resultValue = parsed?.result;
+            const content = event.data?.result?.content ?? "";
+            let parsed;
+            try {
+              parsed = JSON.parse(content);
+            } catch {
+              // Not JSON — show raw
+            }
 
-            // If the tool handler already displayed the full
-            // result (large output), skip re-display here.
-            const wasTruncated =
-              typeof resultValue === "string" &&
-              resultValue.endsWith("[TRUNCATED_FOR_LLM]");
-            if (wasTruncated) {
-              // Already displayed by the tool handler — nothing to do.
-            } else if (resultValue !== undefined) {
-              let displayValue;
-              try {
-                displayValue = JSON.parse(resultValue);
-              } catch {
-                displayValue = resultValue;
-              }
-
-              if (typeof displayValue === "string") {
-                if (displayValue.includes("\n")) {
-                  console.log(`  ${C.ok("✅ Result:")}`);
-                  // Render markdown if enabled and text has markdown patterns;
-                  // otherwise dim the raw text for visual separation.
-                  if (
-                    state.markdownEnabled &&
-                    looksLikeMarkdown(displayValue)
-                  ) {
-                    console.log(renderMarkdown(displayValue));
-                  } else {
-                    console.log(C.dim(displayValue));
-                  }
-                } else {
-                  console.log(`  ${C.ok("✅ Result:")} ${displayValue}`);
-                }
-              } else if (
-                displayValue !== null &&
-                typeof displayValue === "object"
-              ) {
-                const pretty = JSON.stringify(displayValue, null, 2);
-                if (pretty.length > 500) {
-                  console.log(`  ${C.ok("✅ Result:")}`);
-                  // Wrap large JSON in a code block for markdown rendering
-                  if (state.markdownEnabled) {
-                    console.log(renderMarkdown("```json\n" + pretty + "\n```"));
-                  } else {
-                    console.log(C.dim(pretty));
-                  }
-                } else {
-                  console.log(`  ${C.ok("✅ Result:")} ${C.dim(pretty)}`);
-                }
-              } else {
-                console.log(`  ${C.ok("✅ Result:")} ${String(displayValue)}`);
-              }
-            } else if (content) {
-              const preview =
-                content.length > 300 ? content.slice(0, 300) + "…" : content;
-              // Render raw content preview through markdown if enabled
-              if (state.markdownEnabled && looksLikeMarkdown(preview)) {
-                console.log(`  ${C.ok("✅ Result:")}`);
-                console.log(renderMarkdown(preview));
-              } else {
-                console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
+            if (parsed?.error) {
+              // If _userDisplayed is set, the tool handler already
+              // printed the clean error — don't re-display it.
+              if (!parsed._userDisplayed) {
+                console.log(`  ${C.err("❌ " + parsed.error)}`);
+                suggestBufferIncreaseIfNeeded(parsed.error);
               }
             } else {
-              console.log(`  ${C.ok("✅ Tool complete")}`);
+              const resultValue = parsed?.result;
+
+              // If the tool handler already displayed the full
+              // result (large output), skip re-display here.
+              const wasTruncated =
+                typeof resultValue === "string" &&
+                resultValue.endsWith("[TRUNCATED_FOR_LLM]");
+              if (wasTruncated) {
+                // Already displayed by the tool handler — nothing to do.
+              } else if (resultValue !== undefined) {
+                let displayValue;
+                try {
+                  displayValue = JSON.parse(resultValue);
+                } catch {
+                  displayValue = resultValue;
+                }
+
+                if (typeof displayValue === "string") {
+                  if (displayValue.includes("\n")) {
+                    console.log(`  ${C.ok("✅ Result:")}`);
+                    // Render markdown if enabled and text has markdown patterns;
+                    // otherwise dim the raw text for visual separation.
+                    if (
+                      state.markdownEnabled &&
+                      looksLikeMarkdown(displayValue)
+                    ) {
+                      console.log(renderMarkdown(displayValue));
+                    } else {
+                      console.log(C.dim(displayValue));
+                    }
+                  } else {
+                    console.log(`  ${C.ok("✅ Result:")} ${displayValue}`);
+                  }
+                } else if (
+                  displayValue !== null &&
+                  typeof displayValue === "object"
+                ) {
+                  const pretty = JSON.stringify(displayValue, null, 2);
+                  if (pretty.length > 500) {
+                    console.log(`  ${C.ok("✅ Result:")}`);
+                    // Wrap large JSON in a code block for markdown rendering
+                    if (state.markdownEnabled) {
+                      console.log(
+                        renderMarkdown("```json\n" + pretty + "\n```"),
+                      );
+                    } else {
+                      console.log(C.dim(pretty));
+                    }
+                  } else {
+                    console.log(`  ${C.ok("✅ Result:")} ${C.dim(pretty)}`);
+                  }
+                } else {
+                  console.log(
+                    `  ${C.ok("✅ Result:")} ${String(displayValue)}`,
+                  );
+                }
+              } else if (content) {
+                const preview =
+                  content.length > 300 ? content.slice(0, 300) + "…" : content;
+                // Render raw content preview through markdown if enabled
+                if (state.markdownEnabled && looksLikeMarkdown(preview)) {
+                  console.log(`  ${C.ok("✅ Result:")}`);
+                  console.log(renderMarkdown(preview));
+                } else {
+                  console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
+                }
+              } else {
+                console.log(`  ${C.ok("✅ Tool complete")}`);
+              }
             }
-          }
+          } // end verbose gate
         } else {
           // Check if the tool handler already displayed the error to the user
           // (indicated by _userDisplayed flag in the result content). If so,

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -297,6 +297,8 @@ export function registerEventHandler(
 
         spinner.stop();
         console.log(`\n  ${C.tool(`🔧 ${toolName}`)}`);
+        // Restart spinner so the user sees activity while the tool runs
+        spinner.start(" ");
         break;
       }
 
@@ -320,11 +322,23 @@ export function registerEventHandler(
 
         // Show result summary for our sandbox tools
         if (event.data?.success) {
-          // In non-verbose mode, skip the result display —
-          // the LLM will summarise results for the user anyway.
+          // In non-verbose mode, still show errors — but skip verbose
+          // result display since the LLM will summarise for the user.
           if (!state.verboseOutput) {
-            // Brief confirmation so the user knows something happened
-            console.log(`  ${C.ok("✅ Done")}`);
+            const content = event.data?.result?.content ?? "";
+            let parsed;
+            try {
+              parsed = JSON.parse(content);
+            } catch {
+              // Not JSON — that's fine
+            }
+            if (parsed?.error && !parsed._userDisplayed) {
+              // Always show errors, even in non-verbose mode
+              console.log(`  ${C.err("❌ " + parsed.error)}`);
+              suggestBufferIncreaseIfNeeded(parsed.error);
+            } else {
+              console.log(`  ${C.ok("✅ Done")}`);
+            }
           } else {
             const content = event.data?.result?.content ?? "";
             let parsed;
@@ -401,13 +415,9 @@ export function registerEventHandler(
               } else if (content) {
                 const preview =
                   content.length > 300 ? content.slice(0, 300) + "…" : content;
-                // Render raw content preview through markdown if enabled
-                if (state.markdownEnabled && looksLikeMarkdown(preview)) {
-                  console.log(`  ${C.ok("✅ Result:")}`);
-                  console.log(renderMarkdown(preview));
-                } else {
-                  console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
-                }
+                // Don't render truncated content as markdown — truncation
+                // may break mid-token (code fence, table) producing garbled output.
+                console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
               } else {
                 console.log(`  ${C.ok("✅ Tool complete")}`);
               }

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -406,7 +406,7 @@ export function registerEventHandler(
             if (errCode === "denied") {
               console.log(`  ${C.warn("🚫 Tool denied by policy")}`);
             } else {
-              console.log(`  ${C.err("❌ Error:")} ${errMsg}`);
+              console.log(`  ${C.err("❌ Error: " + errMsg)}`);
               suggestBufferIncreaseIfNeeded(errMsg);
             }
           }

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -12,6 +12,7 @@ import type {
 import { C, ANSI } from "./ansi.js";
 import type { AgentState } from "./state.js";
 import type { Spinner } from "./spinner.js";
+import { renderMarkdown, looksLikeMarkdown } from "./markdown-renderer.js";
 import {
   formatUsageStats,
   printUsageStats,
@@ -360,7 +361,16 @@ export function registerEventHandler(
               if (typeof displayValue === "string") {
                 if (displayValue.includes("\n")) {
                   console.log(`  ${C.ok("✅ Result:")}`);
-                  console.log(C.dim(displayValue));
+                  // Render markdown if enabled and text has markdown patterns;
+                  // otherwise dim the raw text for visual separation.
+                  if (
+                    state.markdownEnabled &&
+                    looksLikeMarkdown(displayValue)
+                  ) {
+                    console.log(renderMarkdown(displayValue));
+                  } else {
+                    console.log(C.dim(displayValue));
+                  }
                 } else {
                   console.log(`  ${C.ok("✅ Result:")} ${displayValue}`);
                 }

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -232,8 +232,12 @@ export function registerEventHandler(
           process.stdout.write(`${ANSI.reset}\n\n`);
         }
         // Stream response text token-by-token to stdout
+        // When markdown mode is enabled, buffer silently — the
+        // complete response is rendered at the end by processMessage.
         if (event.data?.deltaContent) {
-          process.stdout.write(event.data.deltaContent);
+          if (!state.markdownEnabled) {
+            process.stdout.write(event.data.deltaContent);
+          }
           state.streamedContent = true;
           state.streamedText += event.data.deltaContent;
         }

--- a/src/agent/event-handler.ts
+++ b/src/agent/event-handler.ts
@@ -381,7 +381,12 @@ export function registerEventHandler(
                 const pretty = JSON.stringify(displayValue, null, 2);
                 if (pretty.length > 500) {
                   console.log(`  ${C.ok("✅ Result:")}`);
-                  console.log(C.dim(pretty));
+                  // Wrap large JSON in a code block for markdown rendering
+                  if (state.markdownEnabled) {
+                    console.log(renderMarkdown("```json\n" + pretty + "\n```"));
+                  } else {
+                    console.log(C.dim(pretty));
+                  }
                 } else {
                   console.log(`  ${C.ok("✅ Result:")} ${C.dim(pretty)}`);
                 }
@@ -391,7 +396,13 @@ export function registerEventHandler(
             } else if (content) {
               const preview =
                 content.length > 300 ? content.slice(0, 300) + "…" : content;
-              console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
+              // Render raw content preview through markdown if enabled
+              if (state.markdownEnabled && looksLikeMarkdown(preview)) {
+                console.log(`  ${C.ok("✅ Result:")}`);
+                console.log(renderMarkdown(preview));
+              } else {
+                console.log(`  ${C.ok("✅ Result:")} ${C.dim(preview)}`);
+              }
             } else {
               console.log(`  ${C.ok("✅ Tool complete")}`);
             }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -119,7 +119,11 @@ import {
   printExtendedReasoningNotice,
   formatTokenSummary,
 } from "./llm-output.js";
-import { renderMarkdown, looksLikeMarkdown } from "./markdown-renderer.js";
+import {
+  renderMarkdown,
+  looksLikeMarkdown,
+  linkifyFiles,
+} from "./markdown-renderer.js";
 
 // ── Session Timing ───────────────────────────────────────────────────
 // Track session start time to display total elapsed time on exit.
@@ -718,7 +722,7 @@ const operatorConfig = loadOperatorConfig();
 
 // Run initial discovery (non-blocking, sync fs reads)
 const discoveredCount = pluginManager.discover();
-if (discoveredCount > 0) {
+if (discoveredCount > 0 && cli.verbose) {
   console.error(`[plugins] Discovered ${discoveredCount} plugin(s)`);
 }
 
@@ -799,7 +803,11 @@ let mcpManager: MCPClientManager | null = null;
           for (const [name, serverConfig] of mcpConfig.servers) {
             mcpManager.registerServer(name, serverConfig);
           }
-          console.error(`[mcp] ${mcpConfig.servers.size} server(s) configured`);
+          if (cli.verbose) {
+            console.error(
+              `[mcp] ${mcpConfig.servers.size} server(s) configured`,
+            );
+          }
         }
       }
     }
@@ -2119,8 +2127,14 @@ const executeJavascriptTool = defineTool("execute_javascript", {
           const outputPath = join(resultsDir, filename);
           writeFileSync(outputPath, fullResult, "utf-8");
           savedPath = `results/${filename}`;
+          const fileIdx = state.producedFiles.length + 1;
+          state.producedFiles.push({
+            index: fileIdx,
+            absPath: outputPath,
+            label: savedPath,
+          });
           console.error(
-            `  ${C.ok("📦")} Result (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${savedPath}`,
+            `  ${C.ok("📦")} [${fileIdx}] Result (${(fullResultBytes / 1024).toFixed(1)} KB) → ${C.fileLink(outputPath, savedPath)}`,
           );
         } else {
           console.error(
@@ -2140,26 +2154,28 @@ const executeJavascriptTool = defineTool("execute_javascript", {
       };
 
       if (fullResult.length > MAX_LLM_RESULT_CHARS) {
-        // Display full result to user in the terminal
-        let displayText: string;
-        try {
-          const parsed = JSON.parse(fullResult);
-          displayText =
-            typeof parsed === "string"
-              ? parsed
-              : JSON.stringify(parsed, null, 2);
-        } catch {
-          displayText = fullResult;
-        }
-        console.error(`  ${C.ok("✅ Result:")}`);
-        if (
-          state.markdownEnabled &&
-          typeof displayText === "string" &&
-          looksLikeMarkdown(displayText)
-        ) {
-          console.error(renderMarkdown(displayText));
-        } else {
-          console.error(displayText);
+        // Display full result to user in verbose mode
+        if (state.verboseOutput) {
+          let displayText: string;
+          try {
+            const parsed = JSON.parse(fullResult);
+            displayText =
+              typeof parsed === "string"
+                ? parsed
+                : JSON.stringify(parsed, null, 2);
+          } catch {
+            displayText = fullResult;
+          }
+          console.error(`  ${C.ok("✅ Result:")}`);
+          if (
+            state.markdownEnabled &&
+            typeof displayText === "string" &&
+            looksLikeMarkdown(displayText)
+          ) {
+            console.error(renderMarkdown(displayText));
+          } else {
+            console.error(displayText);
+          }
         }
 
         // LLM gets first 50K chars + truncation guidance
@@ -2680,8 +2696,14 @@ const executeBashTool = defineTool("execute_bash", {
           const outputPath = join(resultsDir, filename);
           writeFileSync(outputPath, stdout, "utf-8");
           savedPath = `results/${filename}`;
+          const fileIdx = state.producedFiles.length + 1;
+          state.producedFiles.push({
+            index: fileIdx,
+            absPath: outputPath,
+            label: savedPath,
+          });
           console.error(
-            `  ${C.ok("📦")} stdout (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${savedPath}`,
+            `  ${C.ok("📦")} [${fileIdx}] stdout (${(fullResultBytes / 1024).toFixed(1)} KB) → ${C.fileLink(outputPath, savedPath)}`,
           );
         } else {
           console.error(
@@ -2691,20 +2713,22 @@ const executeBashTool = defineTool("execute_bash", {
       }
 
       // ── Step 2: Display output to user ─────────────────────────
-      // Show full output for small results; preview for large ones
-      // to avoid flooding the terminal.
-      if (stdout) {
-        if (fullResultBytes > DISK_SAVE_THRESHOLD_BYTES) {
-          const previewLines = stdout.slice(0, 1024);
-          console.log(previewLines + (stdout.length > 1024 ? "\n..." : ""));
-        } else if (state.markdownEnabled && looksLikeMarkdown(stdout)) {
-          console.log(renderMarkdown(stdout));
-        } else {
-          console.log(stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout);
+      // Show stdout/stderr in verbose mode; in non-verbose the LLM
+      // will summarise results for the user.
+      if (state.verboseOutput) {
+        if (stdout) {
+          if (fullResultBytes > DISK_SAVE_THRESHOLD_BYTES) {
+            const previewLines = stdout.slice(0, 1024);
+            console.log(previewLines + (stdout.length > 1024 ? "\n..." : ""));
+          } else if (state.markdownEnabled && looksLikeMarkdown(stdout)) {
+            console.log(renderMarkdown(stdout));
+          } else {
+            console.log(stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout);
+          }
         }
-      }
-      if (stderr) {
-        console.error("  " + C.dim(stderr.trimEnd()));
+        if (stderr) {
+          console.error("  " + C.dim(stderr.trimEnd()));
+        }
       }
 
       // ── Step 3: Decide what the LLM sees ──────────────────────
@@ -2931,8 +2955,17 @@ async function configureSandboxImpl(params: {
     console.log(
       `\n  ${C.warn("🔧 Assistant wants to change sandbox configuration:")}`,
     );
-    for (const c of changes) {
-      console.log(`     ${c}`);
+    if (state.markdownEnabled) {
+      const rows = changes.map((c) => {
+        const [key, val] = c.split(" → ");
+        return `| ${key} | ${val} |`;
+      });
+      const table = `| Setting | Value |\n|---------|-------|\n${rows.join("\n")}`;
+      console.log(renderMarkdown(table));
+    } else {
+      for (const c of changes) {
+        console.log(`     ${c}`);
+      }
     }
 
     const willRebuild =
@@ -3064,21 +3097,6 @@ async function managePluginImpl(params: {
     console.log(
       `\n  ${C.warn("🔌 Assistant requests plugin:")} ${C.tool(params.name)}`,
     );
-    if (params.config) {
-      if (state.markdownEnabled) {
-        const rows = Object.entries(params.config).map(([k, v]) => {
-          const display = Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
-          return `| ${k} | ${display} |`;
-        });
-        const table = `| Key | Value |\n|-----|-------|\n${rows.join("\n")}`;
-        console.log(renderMarkdown(table));
-      } else {
-        for (const [k, v] of Object.entries(params.config)) {
-          const display = Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
-          console.log(`     ${k}: ${display}`);
-        }
-      }
-    }
     console.log(
       `  ${C.dim("This will run a security audit and prompt for configuration.")}`,
     );
@@ -3237,8 +3255,16 @@ const writeOutputTool = defineTool("write_output", {
 
     writeFileSync(targetPath, params.content, "utf-8");
 
+    // Track produced file for /files and /open commands
+    const fileIdx = state.producedFiles.length + 1;
+    state.producedFiles.push({
+      index: fileIdx,
+      absPath: targetPath,
+      label: params.path,
+    });
+
     console.error(
-      `  ${C.ok("📄")} Wrote ${params.content.length.toLocaleString()} chars → ${params.path}`,
+      `  ${C.ok("📄")} [${fileIdx}] Wrote ${params.content.length.toLocaleString()} chars → ${C.fileLink(targetPath, params.path)}`,
     );
 
     return wrapToolResult({
@@ -4586,7 +4612,9 @@ const manageMCPTool = defineTool("manage_mcp", {
         }
 
         // Connect and discover tools
-        console.error(`[mcp] Connecting to ${params.name}...`);
+        if (state.verboseOutput) {
+          console.error(`[mcp] Connecting to ${params.name}...`);
+        }
         const connected = await mcpManager!.connect(params.name);
 
         // Audit tool descriptions for prompt injection risks
@@ -5439,6 +5467,7 @@ function buildSessionConfig() {
     inputKb: buffers.inputKb,
     outputKb: buffers.outputKb,
     mcpConfigured: mcpManager !== null,
+    markdownEnabled: state.markdownEnabled,
   });
   const pluginAdditions = pluginManager.getSystemMessageAdditions();
 
@@ -5925,6 +5954,7 @@ async function processMessage(
 
   // Arm ESC-key cancellation so the user can bail at any time.
   enableAbortOnEsc(session, state, spinner, debugLog);
+  const fileCountBefore = state.producedFiles.length;
   try {
     const effectiveTimeout = state.sendTimeoutOverride ?? SEND_TIMEOUT_MS;
     const response = await sendAndWaitWithKeepAlive(
@@ -5938,18 +5968,49 @@ async function processMessage(
     // assistant.message content can be empty when the response
     // was delivered via message_delta events.
     const responseForSuggestions = content || state.streamedText;
+
+    // Resolve fs-write base dir for [[file:path]] link replacement
+    const fsWriteBase = getPluginBaseDir("fs-write");
+    // File tracker callback — registers files for /files and /open
+    // Deduplicates by absPath so the same file isn't listed twice
+    const trackFile = (absPath: string, label: string): number => {
+      const existing = state.producedFiles.find((f) => f.absPath === absPath);
+      if (existing) {
+        return existing.index;
+      }
+      const idx = state.producedFiles.length + 1;
+      state.producedFiles.push({ index: idx, absPath, label });
+      return idx;
+    };
+
     if (state.markdownEnabled && state.streamedText) {
       // Markdown mode: output was buffered (not streamed). Render now.
-      const rendered = renderMarkdown(state.streamedText);
+      let rendered = renderMarkdown(state.streamedText);
+      rendered = linkifyFiles(rendered, fsWriteBase, trackFile);
       console.log(rendered);
     } else if (!state.streamedContent && content) {
       // Non-streamed fallback (rare) — render through markdown if enabled
       if (state.markdownEnabled && looksLikeMarkdown(content)) {
-        console.log(renderMarkdown(content));
+        let rendered = renderMarkdown(content);
+        rendered = linkifyFiles(rendered, fsWriteBase, trackFile);
+        console.log(rendered);
       } else {
-        console.log(content);
+        console.log(linkifyFiles(content, fsWriteBase, trackFile));
       }
     }
+
+    // Show file footer if new files were produced during this turn
+    const newFiles = state.producedFiles.slice(fileCountBefore);
+    if (newFiles.length > 0) {
+      console.log();
+      console.log(`  ${ANSI.bold}📂 Files produced:${ANSI.reset}`);
+      for (const f of newFiles) {
+        console.log(
+          `    ${ANSI.cyan}[${f.index}]${ANSI.reset} ${f.label}  ${ANSI.dim}→ /open ${f.index}${ANSI.reset}`,
+        );
+      }
+    }
+
     console.log();
     return responseForSuggestions || undefined;
   } catch (err: unknown) {
@@ -6652,15 +6713,17 @@ async function main(): Promise<void> {
     if (transcript.active) {
       const paths = await transcript.stop();
       console.log("  📄 Transcript saved:");
-      console.log(`     ANSI log:  ${paths.logPath}`);
-      console.log(`     Clean text: ${paths.txtPath}`);
+      console.log(`     ANSI log:   ${C.fileLink(paths.logPath)}`);
+      console.log(`     Clean text: ${C.fileLink(paths.txtPath)}`);
       console.log();
     }
 
     // Close tune stream if active
     if (tuneStream) {
       tuneStream.end();
-      console.log(`  🎛️  Tune log saved: ${tuneLogPath}`);
+      console.log(
+        `  🎛️  Tune log saved: ${tuneLogPath ? C.fileLink(tuneLogPath) : "unknown"}`,
+      );
     }
 
     // Clean up: destroy the session and stop the CLI server
@@ -6703,8 +6766,10 @@ process.on("SIGINT", async () => {
   if (transcript.active) {
     const paths = transcript.stopSync();
     console.log("  📄 Transcript saved:");
-    if (paths.logPath) console.log(`     ANSI log:  ${paths.logPath}`);
-    if (paths.txtPath) console.log(`     Clean text: ${paths.txtPath}`);
+    if (paths.logPath)
+      console.log(`     ANSI log:   ${C.fileLink(paths.logPath)}`);
+    if (paths.txtPath)
+      console.log(`     Clean text: ${C.fileLink(paths.txtPath)}`);
     console.log();
   }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -119,6 +119,7 @@ import {
   printExtendedReasoningNotice,
   formatTokenSummary,
 } from "./llm-output.js";
+import { renderMarkdown, looksLikeMarkdown } from "./markdown-renderer.js";
 
 // ── Session Timing ───────────────────────────────────────────────────
 // Track session start time to display total elapsed time on exit.
@@ -5810,8 +5811,17 @@ async function processMessage(
     // assistant.message content can be empty when the response
     // was delivered via message_delta events.
     const responseForSuggestions = content || state.streamedText;
-    if (!state.streamedContent && content) {
-      console.log(content);
+    if (state.markdownEnabled && state.streamedText) {
+      // Markdown mode: output was buffered (not streamed). Render now.
+      const rendered = renderMarkdown(state.streamedText);
+      console.log(rendered);
+    } else if (!state.streamedContent && content) {
+      // Non-streamed fallback (rare) — render through markdown if enabled
+      if (state.markdownEnabled && looksLikeMarkdown(content)) {
+        console.log(renderMarkdown(content));
+      } else {
+        console.log(content);
+      }
     }
     console.log();
     return responseForSuggestions || undefined;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3097,6 +3097,15 @@ async function managePluginImpl(params: {
     console.log(
       `\n  ${C.warn("🔌 Assistant requests plugin:")} ${C.tool(params.name)}`,
     );
+    if (params.config && Object.keys(params.config).length > 0) {
+      console.log(`  ${C.dim("Requested configuration:")}`);
+      for (const [key, value] of Object.entries(params.config)) {
+        const formattedValue = Array.isArray(value)
+          ? `[${(value as string[]).join(", ")}]`
+          : String(value);
+        console.log(`     ${key}: ${formattedValue}`);
+      }
+    }
     console.log(
       `  ${C.dim("This will run a security audit and prompt for configuration.")}`,
     );

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1122,6 +1122,67 @@ async function handleSlashCommand(
  *     with the CLI server. Raw JSON Schema bypasses this entirely.
  */
 
+// ── Large output constants ───────────────────────────────────────────
+//
+// Two independent thresholds for managing tool output size:
+//
+//   DISK_SAVE_THRESHOLD — save full output to results/ as a backup
+//     for later processing via bash or handlers. The LLM still gets
+//     up to MAX_LLM_RESULT_CHARS of the actual data.
+//
+//   MAX_LLM_RESULT_CHARS — cap on how many characters go to the LLM
+//     in textResultForLlm. ~50K chars ≈ 12K tokens, well within
+//     model context limits and enough for multi-handler orchestration.
+//
+// The disk threshold fires first (saves to disk), then the char
+// threshold decides how much the LLM actually sees. They are
+// independent — saving to disk does NOT starve the LLM.
+
+/** Byte threshold for persisting full output to results/ directory. */
+const DISK_SAVE_THRESHOLD_BYTES = parseInt(
+  process.env.HYPERAGENT_OUTPUT_THRESHOLD_BYTES || "20480",
+  10,
+);
+
+/** Max characters of result data sent to the LLM in textResultForLlm. */
+const MAX_LLM_RESULT_CHARS = 50_000;
+
+/** Marker appended when result is truncated for the LLM. */
+const TRUNCATION_MARKER = "\n[TRUNCATED_FOR_LLM]";
+
+// ── Tool result wrapper ──────────────────────────────────────────────
+
+/**
+ * Wrap a tool handler return value as a proper SDK ToolResultObject.
+ *
+ * Sets `textResultForLlm` to control exactly what the LLM sees, and
+ * `skipLargeOutputProcessing: true` to prevent the SDK's own VB()
+ * function from writing large results to /tmp (inaccessible from
+ * the Hyperlight sandbox).
+ *
+ * Internal fields like _resourceStats and _stats are excluded from
+ * textResultForLlm — they're only needed for terminal display and
+ * waste LLM tokens.
+ *
+ * @param llmFields - Object with fields the LLM should see (result,
+ *   error, consoleOutput, statePreserved, etc.). Will be JSON-stringified.
+ * @param resultType - "success" or "failure" (default: "success")
+ */
+function wrapToolResult(
+  llmFields: Record<string, unknown>,
+  resultType: "success" | "failure" = "success",
+): {
+  textResultForLlm: string;
+  resultType: "success" | "failure";
+  skipLargeOutputProcessing: true;
+} {
+  return {
+    textResultForLlm: JSON.stringify(llmFields),
+    resultType,
+    skipLargeOutputProcessing: true,
+  };
+}
+
 // ── Validation Token Store ────────────────────────────────────────────
 
 /**
@@ -2038,34 +2099,18 @@ const executeJavascriptTool = defineTool("execute_javascript", {
       );
     }
 
-    const resourceStats = timing
-      ? {
-          executeMs: timing.executeMs,
-          totalMs: timing.totalMs,
-          cpuLimitMs: effectiveCpuLimit,
-          wallLimitMs: effectiveWallLimit,
-          cpuUtilisation: `${Math.round((timing.executeMs / effectiveCpuLimit) * 100)}%`,
-          wallUtilisation: `${Math.round((timing.totalMs / effectiveWallLimit) * 100)}%`,
-        }
-      : undefined;
-
     if (success) {
       const fullResult = JSON.stringify(result, null, 2);
       const fullResultBytes = Buffer.byteLength(fullResult, "utf-8");
 
-      // ── Large output interception ──────────────────────────────
-      // If the result exceeds the configured threshold, save to disk
-      // and return a summary with read_output instructions.
-      // This fires BEFORE the SDK's own VB() truncation because we
-      // return a small replacement result.
-      const outputThreshold = parseInt(
-        process.env.HYPERAGENT_OUTPUT_THRESHOLD_BYTES || "20480",
-        10,
-      );
-      if (fullResultBytes > outputThreshold) {
+      // ── Step 1: Persist large output to disk ───────────────────
+      // Save full result to results/ as a backup for later processing.
+      // This is independent of what we send to the LLM — saving to
+      // disk does NOT starve the LLM of data.
+      let savedPath: string | undefined;
+      if (fullResultBytes > DISK_SAVE_THRESHOLD_BYTES) {
         const fsWriteBaseDir = getPluginBaseDir("fs-write");
         if (fsWriteBaseDir) {
-          // Save full result to results/ subdirectory
           const resultsDir = resolve(fsWriteBaseDir, "results");
           if (!existsSync(resultsDir)) {
             mkdirSync(resultsDir, { recursive: true });
@@ -2073,58 +2118,29 @@ const executeJavascriptTool = defineTool("execute_javascript", {
           const filename = `${handlerName}-${Date.now()}.txt`;
           const outputPath = join(resultsDir, filename);
           writeFileSync(outputPath, fullResult, "utf-8");
-          const relativePath = `results/${filename}`;
-
+          savedPath = `results/${filename}`;
           console.error(
-            `  ${C.ok("📦")} Result too large (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${relativePath}`,
+            `  ${C.ok("📦")} Result (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${savedPath}`,
           );
-
-          const preview = fullResult.slice(0, 500);
-          return {
-            result:
-              `Result saved to ${relativePath} (${(fullResultBytes / 1024).toFixed(1)} KB).\n` +
-              `Preview (first 500 chars):\n${preview}\n\n` +
-              `IMPORTANT: Read the full output by writing a handler that reads "${relativePath}" via host:fs-read,\n` +
-              `or use execute_bash to process it (e.g. cat, grep, jq, head, wc).\n` +
-              `Process the data in handler code or bash — do NOT summarize or propose changes based only on the preview.\n` +
-              `Only use read_output("${relativePath}") directly if you need a quick look at a specific section;\n` +
-              `read_output("${relativePath}", startLine, endLine) supports line ranges.`,
-            ...(consoleOutput?.length ? { consoleOutput } : {}),
-            _resourceStats: resourceStats,
-            _stats: stats ?? undefined,
-            _statePreserved: statePreserved,
-          };
         } else {
-          // fs-write not enabled — return truncated preview with guidance
           console.error(
-            `  ${C.warn("⚠️")} Result too large (${(fullResultBytes / 1024).toFixed(1)} KB) and fs-write not enabled`,
+            `  ${C.warn("⚠️")} Result large (${(fullResultBytes / 1024).toFixed(1)} KB) but fs-write not enabled — cannot save to disk`,
           );
-
-          const preview = fullResult.slice(0, 2048);
-          return {
-            result:
-              `Result truncated (${(fullResultBytes / 1024).toFixed(1)} KB). ` +
-              `The fs-write plugin is not enabled, so the full result could not be saved to disk.\n` +
-              `Enable it first: manage_plugin("fs-write", "enable") or apply_profile("file-builder")\n` +
-              `Then re-run the handler to get the full output saved to the results/ directory.\n\n` +
-              `Preview (first 2KB):\n${preview}`,
-            ...(consoleOutput?.length ? { consoleOutput } : {}),
-            _resourceStats: resourceStats,
-            _stats: stats ?? undefined,
-            _statePreserved: statePreserved,
-          };
         }
       }
 
-      const TRUNCATION_MARKER = "\n[TRUNCATED_FOR_LLM]";
-      // Allow up to 50KB of result data in the LLM's context.
-      // The LLM needs the full result to orchestrate multi-handler
-      // workflows (e.g. research handler → build handler). Truncating
-      // at 500 chars forced everything into monolithic handlers.
-      // 50KB is ~12K tokens — well within model context limits.
-      const MAX_LLM_RESULT_CHARS = 50_000;
+      // ── Step 2: Decide what the LLM sees ──────────────────────
+      // The LLM gets up to MAX_LLM_RESULT_CHARS of actual data.
+      // For orchestration workflows the model needs real data, not
+      // just a 500-char preview. Truncation guidance steers toward
+      // processing in the sandbox, not pulling data back into context.
+      const commonLlmFields = {
+        ...(consoleOutput?.length ? { consoleOutput } : {}),
+        ...(statePreserved !== undefined ? { statePreserved } : {}),
+      };
 
       if (fullResult.length > MAX_LLM_RESULT_CHARS) {
+        // Display full result to user in the terminal
         let displayText: string;
         try {
           const parsed = JSON.parse(fullResult);
@@ -2136,42 +2152,60 @@ const executeJavascriptTool = defineTool("execute_javascript", {
           displayText = fullResult;
         }
         console.error(`  ${C.ok("✅ Result:")}`);
-        console.error(displayText);
+        if (
+          state.markdownEnabled &&
+          typeof displayText === "string" &&
+          looksLikeMarkdown(displayText)
+        ) {
+          console.error(renderMarkdown(displayText));
+        } else {
+          console.error(displayText);
+        }
 
+        // LLM gets first 50K chars + truncation guidance
         const preview = fullResult.slice(0, MAX_LLM_RESULT_CHARS);
         const remaining = fullResult.length - MAX_LLM_RESULT_CHARS;
-        return {
-          result:
-            preview +
-            `\n\n[… ${remaining} more characters — full output already displayed to user]` +
-            TRUNCATION_MARKER,
-          ...(consoleOutput?.length ? { consoleOutput } : {}),
-          _resourceStats: resourceStats,
-          _stats: stats ?? undefined,
-          _statePreserved: statePreserved,
-        };
+        const truncationNote = savedPath
+          ? `\n\n[… ${remaining} more characters — full output saved to ${savedPath}]\n` +
+            `Process the full data in the sandbox — do NOT read it back into context.\n` +
+            `• execute_bash: cat ${savedPath} | grep ... | wc -l\n` +
+            `• Handler: import { readFile } from 'host:fs-read'; then process in code` +
+            TRUNCATION_MARKER
+          : `\n\n[… ${remaining} more characters — full output displayed to user]\n` +
+            `Enable fs-write to persist large output: manage_plugin("fs-write", "enable")` +
+            TRUNCATION_MARKER;
+
+        return wrapToolResult({
+          result: preview + truncationNote,
+          ...commonLlmFields,
+        });
       }
-      return {
-        result: fullResult,
-        ...(consoleOutput?.length ? { consoleOutput } : {}),
-        _resourceStats: resourceStats,
-        _stats: stats ?? undefined,
-        _statePreserved: statePreserved,
-      };
+
+      // Result fits in LLM context — include a note about the disk
+      // backup path if one was saved.
+      const resultForLlm = savedPath
+        ? fullResult +
+          `\n\n[Full output also saved to ${savedPath} for processing via bash or handlers]`
+        : fullResult;
+
+      return wrapToolResult({
+        result: resultForLlm,
+        ...commonLlmFields,
+      });
     } else {
       console.log(`  ${C.err("❌ " + error)}`);
       suggestBufferIncreaseIfNeeded(error ?? "");
       const llmError = llmInstruction
         ? `${error} ${llmInstruction}`
         : (error ?? "");
-      return {
-        error: llmError,
-        ...(consoleOutput?.length ? { consoleOutput } : {}),
-        _userDisplayed: true,
-        _resourceStats: resourceStats,
-        _stats: stats ?? undefined,
-        _statePreserved: statePreserved,
-      };
+      return wrapToolResult(
+        {
+          error: llmError,
+          ...(consoleOutput?.length ? { consoleOutput } : {}),
+          _userDisplayed: true,
+        },
+        "failure",
+      );
     }
   },
 });
@@ -2591,10 +2625,13 @@ const executeBashTool = defineTool("execute_bash", {
     // Get the dedicated bash sandbox (created lazily, separate from main JS sandbox)
     const bs = await getBashSandbox();
     if (!bs) {
-      return {
-        error:
-          "Bash module not available. Ensure builtin-modules/bash.js exists (run: just build-bash).",
-      };
+      return wrapToolResult(
+        {
+          error:
+            "Bash module not available. Ensure builtin-modules/bash.js exists (run: just build-bash).",
+        },
+        "failure",
+      );
     }
 
     // Log bash command to code log (same as show-code for JS handlers)
@@ -2626,34 +2663,13 @@ const executeBashTool = defineTool("execute_bash", {
       const stderr = String(result.stderr ?? "");
       const exitCode = Number(result.exitCode ?? 0);
 
-      // ── Large output interception ──────────────────────────────
-      // Check threshold BEFORE printing to avoid flooding the
-      // console with huge output. Same pattern as execute_javascript:
-      // save to disk and return a small summary before the SDK's
-      // VB() truncation (which writes to /tmp — inaccessible from
-      // the sandbox).
-      const outputThreshold = parseInt(
-        process.env.HYPERAGENT_OUTPUT_THRESHOLD_BYTES || "20480",
-        10,
-      );
       const fullResultBytes = Buffer.byteLength(stdout, "utf-8");
-      const isLargeOutput = fullResultBytes > outputThreshold;
 
-      // Show output to user (preview only if large)
-      if (stdout) {
-        if (isLargeOutput) {
-          // Print just a short preview so the terminal isn't flooded
-          const previewLines = stdout.slice(0, 1024);
-          console.log(previewLines + (stdout.length > 1024 ? "\n..." : ""));
-        } else {
-          console.log(stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout);
-        }
-      }
-      if (stderr) {
-        console.error("  " + C.dim(stderr.trimEnd()));
-      }
-
-      if (isLargeOutput) {
+      // ── Step 1: Persist large output to disk ───────────────────
+      // Save full stdout as a backup for later processing via bash.
+      // Independent of what we send to the LLM.
+      let savedPath: string | undefined;
+      if (fullResultBytes > DISK_SAVE_THRESHOLD_BYTES) {
         const fsWriteBaseDir = getPluginBaseDir("fs-write");
         if (fsWriteBaseDir) {
           const resultsDir = resolve(fsWriteBaseDir, "results");
@@ -2663,52 +2679,78 @@ const executeBashTool = defineTool("execute_bash", {
           const filename = `bash-${Date.now()}.txt`;
           const outputPath = join(resultsDir, filename);
           writeFileSync(outputPath, stdout, "utf-8");
-          const relativePath = `results/${filename}`;
-
+          savedPath = `results/${filename}`;
           console.error(
-            `  ${C.ok("📦")} stdout too large (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${relativePath}`,
+            `  ${C.ok("📦")} stdout (${(fullResultBytes / 1024).toFixed(1)} KB) → saved to ${savedPath}`,
           );
-
-          const preview = stdout.slice(0, 500);
-          return {
-            stdout:
-              `Output saved to ${relativePath} (${(fullResultBytes / 1024).toFixed(1)} KB).\n` +
-              `Preview (first 500 chars):\n${preview}\n\n` +
-              `Read the full output with: execute_bash({ command: "cat ${relativePath}" })\n` +
-              `Or process it: execute_bash({ command: "cat ${relativePath} | grep ... | wc -l" })`,
-            stderr,
-            exitCode,
-            ...(consoleOutput?.length ? { consoleOutput } : {}),
-          };
+        } else {
+          console.error(
+            `  ${C.warn("⚠️")} stdout large (${(fullResultBytes / 1024).toFixed(1)} KB) but fs-write not enabled — cannot save to disk`,
+          );
         }
-        // fs-write not enabled — truncate in-place with guidance
-        console.error(
-          `  ${C.warn("⚠️")} stdout too large (${(fullResultBytes / 1024).toFixed(1)} KB) and fs-write not enabled`,
-        );
-        const preview = stdout.slice(0, 2048);
-        return {
-          stdout:
-            `Output truncated (${(fullResultBytes / 1024).toFixed(1)} KB). ` +
-            `Enable fs-write to save large output: manage_plugin("fs-write", "enable")\n\n` +
-            `Preview (first 2KB):\n${preview}`,
+      }
+
+      // ── Step 2: Display output to user ─────────────────────────
+      // Show full output for small results; preview for large ones
+      // to avoid flooding the terminal.
+      if (stdout) {
+        if (fullResultBytes > DISK_SAVE_THRESHOLD_BYTES) {
+          const previewLines = stdout.slice(0, 1024);
+          console.log(previewLines + (stdout.length > 1024 ? "\n..." : ""));
+        } else if (state.markdownEnabled && looksLikeMarkdown(stdout)) {
+          console.log(renderMarkdown(stdout));
+        } else {
+          console.log(stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout);
+        }
+      }
+      if (stderr) {
+        console.error("  " + C.dim(stderr.trimEnd()));
+      }
+
+      // ── Step 3: Decide what the LLM sees ──────────────────────
+      // LLM gets up to MAX_LLM_RESULT_CHARS of actual stdout data.
+      // Truncation guidance steers toward processing in the sandbox.
+      if (stdout.length > MAX_LLM_RESULT_CHARS) {
+        const preview = stdout.slice(0, MAX_LLM_RESULT_CHARS);
+        const remaining = stdout.length - MAX_LLM_RESULT_CHARS;
+        const truncationNote = savedPath
+          ? `\n\n[… ${remaining} more characters — full output saved to ${savedPath}]\n` +
+            `Process the full data with bash: cat ${savedPath} | grep ... | awk ...` +
+            TRUNCATION_MARKER
+          : `\n\n[… ${remaining} more characters — full output displayed to user]\n` +
+            `Enable fs-write to persist large output: manage_plugin("fs-write", "enable")` +
+            TRUNCATION_MARKER;
+
+        return wrapToolResult({
+          stdout: preview + truncationNote,
           stderr,
           exitCode,
           ...(consoleOutput?.length ? { consoleOutput } : {}),
-        };
+        });
       }
 
-      return {
-        stdout,
+      // stdout fits in LLM context — include disk backup note if saved
+      const stdoutForLlm =
+        savedPath && fullResultBytes > DISK_SAVE_THRESHOLD_BYTES
+          ? stdout +
+            `\n\n[Full output also saved to ${savedPath} for processing via bash]`
+          : stdout;
+
+      return wrapToolResult({
+        stdout: stdoutForLlm,
         stderr,
         exitCode,
         ...(consoleOutput?.length ? { consoleOutput } : {}),
-      };
+      });
     } else {
       console.error("  " + C.err("❌ " + (error ?? "Unknown bash error")));
-      return {
-        error: error ?? "Bash execution failed",
-        ...(consoleOutput?.length ? { consoleOutput } : {}),
-      };
+      return wrapToolResult(
+        {
+          error: error ?? "Bash execution failed",
+          ...(consoleOutput?.length ? { consoleOutput } : {}),
+        },
+        "failure",
+      );
     }
   },
 });
@@ -3023,9 +3065,18 @@ async function managePluginImpl(params: {
       `\n  ${C.warn("🔌 Assistant requests plugin:")} ${C.tool(params.name)}`,
     );
     if (params.config) {
-      for (const [k, v] of Object.entries(params.config)) {
-        const display = Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
-        console.log(`     ${k}: ${display}`);
+      if (state.markdownEnabled) {
+        const rows = Object.entries(params.config).map(([k, v]) => {
+          const display = Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
+          return `| ${k} | ${display} |`;
+        });
+        const table = `| Key | Value |\n|-----|-------|\n${rows.join("\n")}`;
+        console.log(renderMarkdown(table));
+      } else {
+        for (const [k, v] of Object.entries(params.config)) {
+          const display = Array.isArray(v) ? `[${v.join(", ")}]` : String(v);
+          console.log(`     ${k}: ${display}`);
+        }
       }
     }
     console.log(
@@ -3162,15 +3213,18 @@ const writeOutputTool = defineTool("write_output", {
   handler: async (params: { path: string; content: string }) => {
     const baseDir = getPluginBaseDir("fs-write");
     if (!baseDir) {
-      return {
-        error:
-          "fs-write plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
-      };
+      return wrapToolResult(
+        {
+          error:
+            "fs-write plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
+        },
+        "failure",
+      );
     }
 
     const check = validatePath(params.path, baseDir);
     if (!check.valid) {
-      return { error: check.error };
+      return wrapToolResult({ error: check.error }, "failure");
     }
 
     const targetPath = resolve(baseDir, params.path);
@@ -3187,12 +3241,12 @@ const writeOutputTool = defineTool("write_output", {
       `  ${C.ok("📄")} Wrote ${params.content.length.toLocaleString()} chars → ${params.path}`,
     );
 
-    return {
+    return wrapToolResult({
       success: true,
       path: params.path,
       bytes: Buffer.byteLength(params.content, "utf-8"),
       directory: baseDir,
-    };
+    });
   },
 });
 
@@ -3224,21 +3278,27 @@ const readInputTool = defineTool("read_input", {
   handler: async (params: { path: string }) => {
     const baseDir = getPluginBaseDir("fs-read");
     if (!baseDir) {
-      return {
-        error:
-          "fs-read plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
-      };
+      return wrapToolResult(
+        {
+          error:
+            "fs-read plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
+        },
+        "failure",
+      );
     }
 
     const check = validatePath(params.path, baseDir);
     if (!check.valid) {
-      return { error: check.error };
+      return wrapToolResult({ error: check.error }, "failure");
     }
 
     const targetPath = resolve(baseDir, params.path);
 
     if (!existsSync(targetPath)) {
-      return { error: `File not found: ${params.path}` };
+      return wrapToolResult(
+        { error: `File not found: ${params.path}` },
+        "failure",
+      );
     }
 
     const content = readFileSync(targetPath, "utf-8");
@@ -3247,11 +3307,31 @@ const readInputTool = defineTool("read_input", {
       `  ${C.ok("📖")} Read ${content.length.toLocaleString()} chars ← ${params.path}`,
     );
 
-    return {
+    // Guard against sending huge files into LLM context.
+    // Steer the LLM toward processing in the sandbox instead.
+    if (content.length > MAX_LLM_RESULT_CHARS) {
+      const preview = content.slice(0, MAX_LLM_RESULT_CHARS);
+      const remaining = content.length - MAX_LLM_RESULT_CHARS;
+      return wrapToolResult({
+        content:
+          preview +
+          `\n\n[… ${remaining} more characters — file too large for context]\n` +
+          `Process the full file in the sandbox instead of reading more into context:\n` +
+          `• execute_bash: cat ${params.path} | grep ... | awk '{...}'\n` +
+          `• Handler: import { readFile } from 'host:fs-read'; then process in code` +
+          TRUNCATION_MARKER,
+        path: params.path,
+        bytes: Buffer.byteLength(content, "utf-8"),
+        totalChars: content.length,
+        truncated: true,
+      });
+    }
+
+    return wrapToolResult({
       content,
       path: params.path,
       bytes: Buffer.byteLength(content, "utf-8"),
-    };
+    });
   },
 });
 
@@ -3298,21 +3378,27 @@ const readOutputTool = defineTool("read_output", {
   }) => {
     const baseDir = getPluginBaseDir("fs-write");
     if (!baseDir) {
-      return {
-        error:
-          "fs-write plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
-      };
+      return wrapToolResult(
+        {
+          error:
+            "fs-write plugin is not enabled. Enable it first with manage_plugin or apply_profile, then try again.",
+        },
+        "failure",
+      );
     }
 
     const check = validatePath(params.path, baseDir);
     if (!check.valid) {
-      return { error: check.error };
+      return wrapToolResult({ error: check.error }, "failure");
     }
 
     const targetPath = resolve(baseDir, params.path);
 
     if (!existsSync(targetPath)) {
-      return { error: `File not found: ${params.path}` };
+      return wrapToolResult(
+        { error: `File not found: ${params.path}` },
+        "failure",
+      );
     }
 
     const fullContent = readFileSync(targetPath, "utf-8");
@@ -3329,13 +3415,35 @@ const readOutputTool = defineTool("read_output", {
       `  ${C.ok("📖")} Read ${params.path} lines ${start}-${end} of ${totalLines} (${content.length.toLocaleString()} chars)`,
     );
 
-    return {
+    // Guard against sending huge content into LLM context.
+    // Steer toward using line ranges or processing in the sandbox.
+    if (content.length > MAX_LLM_RESULT_CHARS) {
+      const preview = content.slice(0, MAX_LLM_RESULT_CHARS);
+      const remaining = content.length - MAX_LLM_RESULT_CHARS;
+      return wrapToolResult({
+        content:
+          preview +
+          `\n\n[… ${remaining} more characters — content too large for context]\n` +
+          `Use startLine/endLine to read specific sections, or process in the sandbox:\n` +
+          `• read_output("${params.path}", startLine, endLine) for targeted reads\n` +
+          `• execute_bash: cat ${params.path} | grep ... | awk '{...}'\n` +
+          `• Handler: import { readFile } from 'host:fs-read'; then process in code` +
+          TRUNCATION_MARKER,
+        path: params.path,
+        totalLines,
+        range: { start, end },
+        bytes: Buffer.byteLength(content, "utf-8"),
+        truncated: true,
+      });
+    }
+
+    return wrapToolResult({
       content,
       path: params.path,
       totalLines,
       range: { start, end },
       bytes: Buffer.byteLength(content, "utf-8"),
-    };
+    });
   },
 });
 
@@ -6043,54 +6151,53 @@ async function main(): Promise<void> {
   }
 
   console.log();
-  console.log(`  ${bold}Configuration:${reset}`);
-  console.log(`    Model:         ${cyan}${state.currentModel}${reset}`);
-  console.log(
-    `    CPU timeout:   ${cyan}${sandbox.config.cpuTimeoutMs}ms${reset}`,
-  );
-  console.log(
-    `    Wall timeout:  ${cyan}${sandbox.config.wallClockTimeoutMs}ms${reset}`,
-  );
-  console.log(
-    `    Send timeout:  ${cyan}${SEND_TIMEOUT_MS}ms${reset} ${dim}(inactivity)${reset}`,
-  );
-  console.log(
-    `    Heap size:     ${cyan}${sandbox.config.heapSizeMb}MB${reset}`,
-  );
-  console.log(
-    `    Scratch size:  ${cyan}${sandbox.config.scratchSizeMb}MB${reset}`,
-  );
-  console.log(
-    `    Buffers:       ${cyan}${sandbox.config.inputBufferKb}KB${reset} input / ${cyan}${sandbox.config.outputBufferKb}KB${reset} output`,
-  );
-  console.log(`    Context:       infinite sessions (auto-compaction)`);
-  {
-    const bannerPlugins = pluginManager.listPlugins();
-    const bannerEnabled = pluginManager.getEnabledPlugins();
-    if (bannerPlugins.length > 0) {
-      const audited = bannerPlugins.filter((p) => p.audit !== null).length;
-      const approved = bannerPlugins.filter((p) => p.approved).length;
-      console.log(
-        `    Plugins:       ${green}${bannerEnabled.length}/${bannerPlugins.length}${reset} enabled, ${audited} audited, ${approved} approved`,
-      );
-    } else {
-      console.log(
-        `    Plugins:       ${dim}none (create plugins/ directory to extend)${reset}`,
-      );
-    }
-  }
+  // Build config rows as key-value pairs for both plain and markdown display
+  const bannerPlugins = pluginManager.listPlugins();
+  const bannerEnabled = pluginManager.getEnabledPlugins();
+  const pluginSummary =
+    bannerPlugins.length > 0
+      ? (() => {
+          const audited = bannerPlugins.filter((p) => p.audit !== null).length;
+          const approved = bannerPlugins.filter((p) => p.approved).length;
+          return `${bannerEnabled.length}/${bannerPlugins.length} enabled, ${audited} audited, ${approved} approved`;
+        })()
+      : "none (create plugins/ directory to extend)";
+
+  type ConfigRow = [label: string, value: string];
+  const configRows: ConfigRow[] = [
+    ["Model", state.currentModel],
+    ["CPU timeout", `${sandbox.config.cpuTimeoutMs}ms`],
+    ["Wall timeout", `${sandbox.config.wallClockTimeoutMs}ms`],
+    ["Send timeout", `${SEND_TIMEOUT_MS}ms (inactivity)`],
+    ["Heap size", `${sandbox.config.heapSizeMb}MB`],
+    ["Scratch size", `${sandbox.config.scratchSizeMb}MB`],
+    [
+      "Buffers",
+      `${sandbox.config.inputBufferKb}KB input / ${sandbox.config.outputBufferKb}KB output`,
+    ],
+    ["Context", "infinite sessions (auto-compaction)"],
+    ["Plugins", pluginSummary],
+  ];
   if (cli.showCode && process.env.HYPERAGENT_CODE_LOG) {
-    console.log(
-      `    Code log:      ${green}${process.env.HYPERAGENT_CODE_LOG}${reset}`,
-    );
+    configRows.push(["Code log", process.env.HYPERAGENT_CODE_LOG]);
   }
   if (cli.showTiming && process.env.HYPERAGENT_TIMING_LOG) {
-    console.log(
-      `    Timing log:    ${green}${process.env.HYPERAGENT_TIMING_LOG}${reset}`,
-    );
+    configRows.push(["Timing log", process.env.HYPERAGENT_TIMING_LOG]);
   }
   if (transcript.active) {
-    console.log(`    Transcript:    ${green}${transcript.rawPath}${reset}`);
+    configRows.push(["Transcript", transcript.rawPath ?? ""]);
+  }
+
+  if (state.markdownEnabled) {
+    const mdRows = configRows.map(([k, v]) => `| ${k} | ${v} |`).join("\n");
+    const table = `| Setting | Value |\n|---------|-------|\n${mdRows}`;
+    console.log(`  **Configuration:**`);
+    console.log(renderMarkdown(table));
+  } else {
+    console.log(`  ${bold}Configuration:${reset}`);
+    for (const [label, value] of configRows) {
+      console.log(`    ${label.padEnd(14)} ${cyan}${value}${reset}`);
+    }
   }
   console.log();
   console.log(

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1372,11 +1372,24 @@ const registerHandlerTool = defineTool("register_handler", {
   },
   handler: async ({ name, code }: { name: string; code: string }) => {
     if (state.showCodeEnabled) {
-      const indented = code
-        .split("\n")
-        .map((l: string) => `    ${l}`)
-        .join("\n");
-      console.error(`\n  📝 register_handler("${name}"):\n${indented}\n`);
+      // Syntax-highlight code via markdown renderer when enabled;
+      // otherwise fall back to plain indented display.
+      if (state.markdownEnabled) {
+        const mdBlock = "```javascript\n" + code + "\n```";
+        console.error(
+          '\n  📝 register_handler("' +
+            name +
+            '"):\n' +
+            renderMarkdown(mdBlock) +
+            "\n",
+        );
+      } else {
+        const indented = code
+          .split("\n")
+          .map((l: string) => `    ${l}`)
+          .join("\n");
+        console.error(`\n  📝 register_handler("${name}"):\n${indented}\n`);
+      }
     }
     sandbox.writeCode(`// ── handler: ${name} ──\n${code}\n`);
 
@@ -2586,7 +2599,13 @@ const executeBashTool = defineTool("execute_bash", {
 
     // Log bash command to code log (same as show-code for JS handlers)
     if (state.showCodeEnabled) {
-      console.log("  " + C.dim("$ " + command));
+      // Syntax-highlight bash commands via markdown renderer when enabled
+      if (state.markdownEnabled) {
+        const mdBlock = "```bash\n$ " + command + "\n```";
+        console.log(renderMarkdown(mdBlock));
+      } else {
+        console.log("  " + C.dim("$ " + command));
+      }
     }
     sandbox.writeCode("// ── bash ──\n$ " + command + "\n");
 

--- a/src/agent/markdown-renderer.ts
+++ b/src/agent/markdown-renderer.ts
@@ -1,0 +1,65 @@
+// ── Terminal Markdown Renderer ────────────────────────────────────────
+//
+// Renders markdown text as ANSI-formatted terminal output using
+// marked + marked-terminal. Used when --markdown mode is enabled
+// to make LLM output readable instead of raw markdown syntax.
+//
+// Usage:
+//   import { renderMarkdown } from "./markdown-renderer.js";
+//   console.log(renderMarkdown("# Hello\n**bold** and `code`"));
+
+import { marked, type MarkedOptions } from "marked";
+import TerminalRenderer from "marked-terminal";
+
+// Configure marked with the terminal renderer once at import time.
+// marked-terminal handles: headings, bold/italic, code blocks with
+// syntax highlighting, lists, tables, links, blockquotes, and hr.
+const renderer = new TerminalRenderer({
+  // Indent code blocks for visual separation
+  tab: 2,
+  // Show URLs inline rather than as footnotes
+  showSectionPrefix: true,
+  // Use unicode bullets
+  unescape: true,
+});
+// marked-terminal's renderer type doesn't match marked v15's _Renderer
+// exactly, but it works at runtime. Cast to satisfy the type checker.
+marked.setOptions({
+  renderer: renderer as unknown as MarkedOptions["renderer"],
+});
+
+/**
+ * Render a markdown string as ANSI-formatted terminal output.
+ *
+ * Returns the rendered string with ANSI escape codes for colours,
+ * bold, underline, etc. The caller is responsible for printing it.
+ *
+ * Trailing whitespace is trimmed to avoid extra blank lines.
+ *
+ * @param text - Raw markdown text from the LLM
+ * @returns ANSI-formatted string ready for console output
+ */
+export function renderMarkdown(text: string): string {
+  // marked.parse() can return string | Promise<string> depending on
+  // config. With our sync renderer it always returns string.
+  const rendered = marked.parse(text) as string;
+  // Trim trailing newlines that marked adds (avoids double-spacing)
+  return rendered.replace(/\n+$/, "");
+}
+
+/**
+ * Check if text looks like it contains markdown formatting.
+ * Used to decide whether rendering would add value — plain text
+ * doesn't benefit from being passed through the renderer.
+ */
+export function looksLikeMarkdown(text: string): boolean {
+  // Quick heuristics — check for common markdown patterns
+  return (
+    /^#{1,6}\s/m.test(text) || // headings
+    /\*\*[^*]+\*\*/m.test(text) || // bold
+    /```[\s\S]*?```/m.test(text) || // code blocks
+    /^\s*[-*+]\s/m.test(text) || // unordered lists
+    /^\s*\d+\.\s/m.test(text) || // ordered lists
+    /\|.*\|.*\|/m.test(text) // tables
+  );
+}

--- a/src/agent/markdown-renderer.ts
+++ b/src/agent/markdown-renderer.ts
@@ -1,7 +1,7 @@
 // ── Terminal Markdown Renderer ────────────────────────────────────────
 //
 // Renders markdown text as ANSI-formatted terminal output using
-// marked + marked-terminal. Used when --markdown mode is enabled
+// marked + marked-terminal. Used when markdown mode is enabled (default)
 // to make LLM output readable instead of raw markdown syntax.
 //
 // Usage:
@@ -10,6 +10,7 @@
 
 import { marked, type MarkedOptions } from "marked";
 import TerminalRenderer from "marked-terminal";
+import { resolve } from "node:path";
 
 // Configure marked with the terminal renderer once at import time.
 // marked-terminal handles: headings, bold/italic, code blocks with
@@ -62,4 +63,43 @@ export function looksLikeMarkdown(text: string): boolean {
     /^\s*\d+\.\s/m.test(text) || // ordered lists
     /\|.*\|.*\|/m.test(text) // tables
   );
+}
+
+// ── File Link Post-Processor ─────────────────────────────────────────
+//
+// Converts [[file:path]] markers in LLM output into clickable OSC 8
+// terminal hyperlinks. The LLM is instructed (via system message) to
+// use this format when summarising produced files.
+
+/** Regex to match [[file:path]] markers in LLM output. */
+const FILE_LINK_RE = /\[\[file:([^\]]+)\]\]/g;
+
+/** Callback to register a produced file and get its reference number. */
+export type FileTracker = (absPath: string, label: string) => number;
+
+/**
+ * Replace [[file:path]] markers with numbered references and absolute
+ * paths. Registers each file via the tracker callback for later
+ * retrieval via `/files` and `/open` commands.
+ *
+ * @param text - Rendered text (post-markdown or raw)
+ * @param baseDir - Absolute path to the fs-write base directory
+ * @param trackFile - Callback to register file and get its index
+ * @returns Text with [[file:]] markers replaced
+ */
+export function linkifyFiles(
+  text: string,
+  baseDir: string | null,
+  trackFile?: FileTracker,
+): string {
+  if (!baseDir) return text.replaceAll(FILE_LINK_RE, "$1");
+  return text.replaceAll(FILE_LINK_RE, (_match, relPath: string) => {
+    const trimmed = relPath.trim();
+    const absPath = resolve(baseDir, trimmed);
+    if (trackFile) {
+      const idx = trackFile(absPath, trimmed);
+      return `${absPath} [${idx}]`;
+    }
+    return absPath;
+  });
 }

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -276,6 +276,18 @@ export async function handleSlashCommand(
       return true;
     }
 
+    case "/markdown":
+    case "/md": {
+      // Toggle markdown rendering — buffers output instead of streaming
+      // and renders through marked-terminal for proper formatting.
+      state.markdownEnabled = !state.markdownEnabled;
+      console.log(
+        `  📝 Markdown rendering: ${state.markdownEnabled ? C.ok("ON") + C.dim(" (output buffered, not streamed)") : C.err("OFF") + C.dim(" (raw streaming)")}`,
+      );
+      console.log();
+      return true;
+    }
+
     case "/timeout": {
       const kind = parts[1]?.toLowerCase();
       const ms = parseInt(parts[2], 10);

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -858,6 +858,70 @@ export async function handleSlashCommand(
       return true;
     }
 
+    case "/files": {
+      // List all files produced during this session
+      if (state.producedFiles.length === 0) {
+        console.log(`  ${C.dim("No files produced yet in this session.")}`);
+      } else {
+        console.log(`  ${C.label("📂 Files produced this session:")}`);
+        for (const f of state.producedFiles) {
+          console.log(
+            `    ${C.val(`[${f.index}]`)} ${f.absPath} ${C.dim(`(${f.label})`)}`,
+          );
+        }
+        console.log(
+          `\n  ${C.dim("Use /open <n> to open a file, e.g. /open 1")}`,
+        );
+      }
+      console.log();
+      return true;
+    }
+
+    case "/open": {
+      // Open a produced file by its reference number
+      const fileNum = parseInt(parts[1] ?? "", 10);
+      if (!parts[1] || !Number.isFinite(fileNum) || fileNum < 1) {
+        console.log(
+          `  ${C.err("Usage: /open <n>")} — open a produced file by number.`,
+        );
+        console.log(`  ${C.dim("Run /files to see available files.")}`);
+        console.log();
+        return true;
+      }
+      const file = state.producedFiles.find((f) => f.index === fileNum);
+      if (!file) {
+        console.log(
+          `  ${C.err(`File [${fileNum}] not found.`)} Run /files to see available files.`,
+        );
+        console.log();
+        return true;
+      }
+      // Use xdg-open on Linux, open on macOS, cmd.exe /c start on WSL
+      const { execSync } = await import("child_process");
+      try {
+        // Detect WSL — convert to Windows path and use cmd.exe /c start
+        const isWSL = existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
+        if (isWSL) {
+          const winPath = execSync(`wslpath -w "${file.absPath}"`, {
+            encoding: "utf-8",
+          }).trim();
+          execSync(`cmd.exe /c start '' '${winPath}'`, { stdio: "ignore" });
+        } else if (process.platform === "darwin") {
+          execSync(`open "${file.absPath}"`, { stdio: "ignore" });
+        } else {
+          execSync(`xdg-open "${file.absPath}"`, { stdio: "ignore" });
+        }
+        console.log(`  ${C.ok("✅")} Opened [${fileNum}] ${file.label}`);
+      } catch (err) {
+        console.log(
+          `  ${C.err("❌")} Failed to open: ${(err as Error).message}`,
+        );
+        console.log(`  ${C.dim("Path:")} ${file.absPath}`);
+      }
+      console.log();
+      return true;
+    }
+
     case "/history": {
       // Display recent conversation messages from the active session.
       // Uses the SDK's session.getMessages() to retrieve the full
@@ -1218,12 +1282,24 @@ export async function handleSlashCommand(
             pluginManager.markSandboxDirty();
 
             console.log(`  🔄 "${pluginName}" reconfigured:`);
-            for (const key of applied) {
-              const val = targetPlugin.config[key];
-              const display = Array.isArray(val)
-                ? `[${(val as string[]).join(", ")}]`
-                : String(val);
-              console.log(`     ${key} = ${display}`);
+            if (state.markdownEnabled) {
+              const rows = applied.map((key) => {
+                const val = targetPlugin.config[key];
+                const display = Array.isArray(val)
+                  ? `[${(val as string[]).join(", ")}]`
+                  : String(val);
+                return `| ${key} | ${display} |`;
+              });
+              const table = `| Key | Value |\n|-----|-------|\n${rows.join("\n")}`;
+              console.log(renderMarkdown(table));
+            } else {
+              for (const key of applied) {
+                const val = targetPlugin.config[key];
+                const display = Array.isArray(val)
+                  ? `[${(val as string[]).join(", ")}]`
+                  : String(val);
+                console.log(`     ${key} = ${display}`);
+              }
             }
             console.log("     Changes take effect on the next message.");
             console.log();

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -18,6 +18,7 @@ import { renderHelp, renderTopicHelp } from "./commands.js";
 import { deepAudit, formatAuditResult } from "../plugin-system/auditor.js";
 import { makeAuditProgressCallback } from "./audit-progress.js";
 import { createAuditAbortHandler } from "./abort-controller.js";
+import { renderMarkdown } from "./markdown-renderer.js";
 import { closestMatch } from "./fuzzy-match.js";
 import type { createSandboxTool } from "../sandbox/tool.js";
 import type { createPluginManager } from "../plugin-system/manager.js";
@@ -55,6 +56,22 @@ function makeSessionId(): string {
   return `${SESSION_ID_PREFIX}${randomUUID()}`;
 }
 const operatorConfig = loadOperatorConfig();
+
+/**
+ * Convert formatConfigSummary lines into a markdown table.
+ * Lines have format "  key: value" or "  key: value (default)".
+ */
+function formatConfigTable(lines: string[]): string {
+  const rows = lines.map((line) => {
+    const trimmed = line.trim();
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) return `| ${trimmed} | |`;
+    const key = trimmed.slice(0, colonIdx).trim();
+    const value = trimmed.slice(colonIdx + 1).trim();
+    return `| ${key} | ${value} |`;
+  });
+  return `| Key | Value |\n|-----|-------|\n${rows.join("\n")}`;
+}
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -754,54 +771,49 @@ export async function handleSlashCommand(
       const sendMs = state.sendTimeoutOverride ?? SEND_TIMEOUT_MS;
       const buffers = sandbox.getEffectiveBufferSizes();
       const ovr = C.warn(" (override)");
-      console.log(`  ${C.label("⚙️  Configuration:")}`);
-      console.log(`     Model:         ${C.val(state.currentModel)}`);
-      console.log(
-        `     CPU timeout:   ${C.val(cpuMs + "ms")}${state.cpuTimeoutOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Wall timeout:  ${C.val(wallMs + "ms")}${state.wallTimeoutOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Send timeout:  ${C.val(sendMs + "ms")}${state.sendTimeoutOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Heap:          ${C.val(sandbox.getEffectiveMemorySizes().heapMb + "MB")}${state.heapOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Scratch:        ${C.val(sandbox.getEffectiveMemorySizes().scratchMb + "MB")}${state.scratchOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Input buffer:  ${C.val(buffers.inputKb + "KB")}${state.inputBufferOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Output buffer: ${C.val(buffers.outputKb + "KB")}${state.outputBufferOverride !== null ? ovr : ""}`,
-      );
-      console.log(
-        `     Transcript:    ${transcript.active ? `${C.ok("ON")} → ${C.val(transcript.rawPath ?? "")}` : C.err("OFF")}`,
-      );
-      console.log(`     Show code:     ${C.onOff(state.showCodeEnabled)}`);
-      console.log(`     Show timing:   ${C.onOff(state.showTimingEnabled)}`);
-      console.log(`     Debug:         ${C.onOff(state.debugEnabled)}`);
-      console.log(`     Verbose:       ${C.onOff(state.verboseOutput)}`);
-      console.log(
-        `     Reasoning:     conversation: ${
-          state.reasoningEffort
-            ? C.val(state.reasoningEffort)
-            : C.dim("model default")
-        } · audit: ${
-          state.auditReasoningEffort
-            ? C.val(state.auditReasoningEffort)
-            : C.dim("medium")
-        }`,
-      );
+      // Build config rows for both plain and markdown display
+      const mem = sandbox.getEffectiveMemorySizes();
+      const ovrTag = " ⚠ override";
+      type CfgRow = [label: string, value: string, override: boolean];
+      const cfgRows: CfgRow[] = [
+        ["Model", state.currentModel, false],
+        ["CPU timeout", cpuMs + "ms", state.cpuTimeoutOverride !== null],
+        ["Wall timeout", wallMs + "ms", state.wallTimeoutOverride !== null],
+        ["Send timeout", sendMs + "ms", state.sendTimeoutOverride !== null],
+        ["Heap", mem.heapMb + "MB", state.heapOverride !== null],
+        ["Scratch", mem.scratchMb + "MB", state.scratchOverride !== null],
+        [
+          "Input buffer",
+          buffers.inputKb + "KB",
+          state.inputBufferOverride !== null,
+        ],
+        [
+          "Output buffer",
+          buffers.outputKb + "KB",
+          state.outputBufferOverride !== null,
+        ],
+        [
+          "Transcript",
+          transcript.active ? `ON → ${transcript.rawPath ?? ""}` : "OFF",
+          false,
+        ],
+        ["Show code", state.showCodeEnabled ? "ON" : "OFF", false],
+        ["Show timing", state.showTimingEnabled ? "ON" : "OFF", false],
+        ["Debug", state.debugEnabled ? "ON" : "OFF", false],
+        ["Verbose", state.verboseOutput ? "ON" : "OFF", false],
+        [
+          "Reasoning",
+          `conversation: ${
+            state.reasoningEffort ?? "model default"
+          } · audit: ${state.auditReasoningEffort ?? "medium"}`,
+          false,
+        ],
+      ];
       if (sandbox.config.timingLogPath) {
-        console.log(
-          `     Timing log:   ${C.val(sandbox.config.timingLogPath)}`,
-        );
+        cfgRows.push(["Timing log", sandbox.config.timingLogPath, false]);
       }
       if (sandbox.config.codeLogPath) {
-        console.log(`     Code log:     ${C.val(sandbox.config.codeLogPath)}`);
+        cfgRows.push(["Code log", sandbox.config.codeLogPath, false]);
       }
       // Plugin summary
       const enabledPlugins = pluginManager.getEnabledPlugins();
@@ -809,17 +821,35 @@ export async function handleSlashCommand(
       if (allPlugins.length > 0) {
         const audited = allPlugins.filter((p) => p.audit !== null).length;
         const approved = allPlugins.filter((p) => p.approved).length;
-        console.log(
-          `     Plugins:      ${C.ok(enabledPlugins.length + "/" + allPlugins.length)} enabled, ${audited} audited, ${approved} approved`,
-        );
+        cfgRows.push([
+          "Plugins",
+          `${enabledPlugins.length}/${allPlugins.length} enabled, ${audited} audited, ${approved} approved`,
+          false,
+        ]);
+      } else {
+        cfgRows.push(["Plugins", "none discovered", false]);
+      }
+
+      if (state.markdownEnabled) {
+        const mdRows = cfgRows
+          .map(([k, v, isOvr]) => `| ${k} | ${v}${isOvr ? ovrTag : ""} |`)
+          .join("\n");
+        const table = `| Setting | Value |\n|---------|-------|\n${mdRows}`;
+        console.log(`  **⚙️  Configuration:**`);
+        console.log(renderMarkdown(table));
+      } else {
+        console.log(`  ${C.label("⚙️  Configuration:")}`);
+        for (const [label, value, isOvr] of cfgRows) {
+          const ovrSuffix = isOvr ? ovr : "";
+          console.log(`     ${label.padEnd(15)} ${C.val(value)}${ovrSuffix}`);
+        }
+        // Show enabled plugin details in plain mode
         for (const p of enabledPlugins) {
           const risk = p.audit?.riskLevel ?? "?";
           console.log(
             `       ${C.ok("✅")} ${C.tool(p.manifest.name)} v${p.manifest.version} ${C.dim("[" + risk + "]")}`,
           );
         }
-      } else {
-        console.log(`     ${C.dim("Plugins:      none discovered")}`);
       }
       console.log(
         `     Risk policy:  ${C.val("max " + operatorConfig.maxRiskLevel)} ${C.dim("(via ~/.hyperagent/config.json)")}`,
@@ -1291,8 +1321,13 @@ export async function handleSlashCommand(
             const configSummary = pluginManager.formatConfigSummary(pluginName);
             if (configSummary.length > 0) {
               console.log(`\n  📋 Final configuration for "${pluginName}":`);
-              for (const line of configSummary) {
-                console.log(`    ${line}`);
+              if (state.markdownEnabled) {
+                const table = formatConfigTable(configSummary);
+                console.log(renderMarkdown(table));
+              } else {
+                for (const line of configSummary) {
+                  console.log(`    ${line}`);
+                }
               }
 
               await drainAndWarn(rl);
@@ -1613,8 +1648,13 @@ export async function handleSlashCommand(
           const configSummary = pluginManager.formatConfigSummary(pluginName);
           if (configSummary.length > 0) {
             console.log(`\n  📋 Final configuration for "${pluginName}":`);
-            for (const line of configSummary) {
-              console.log(`    ${line}`);
+            if (state.markdownEnabled) {
+              const table = formatConfigTable(configSummary);
+              console.log(renderMarkdown(table));
+            } else {
+              for (const line of configSummary) {
+                console.log(`    ${line}`);
+              }
             }
 
             await drainAndWarn(rl);

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -460,7 +460,7 @@ export async function handleSlashCommand(
         console.log(formatModelList(models, state.currentModel));
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to list models:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to list models: " + msg)}`);
       }
       console.log();
       return true;
@@ -516,7 +516,7 @@ export async function handleSlashCommand(
         console.log("     Conversation history preserved.");
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to switch model:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to switch model: " + msg)}`);
       }
       console.log();
       return true;
@@ -543,7 +543,7 @@ export async function handleSlashCommand(
         console.log(`     Model: ${C.val(state.currentModel)}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to create new session:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to create new session: " + msg)}`);
       }
       console.log();
       return true;
@@ -614,7 +614,7 @@ export async function handleSlashCommand(
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to list sessions:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to list sessions: " + msg)}`);
       }
       console.log();
       return true;
@@ -741,7 +741,7 @@ export async function handleSlashCommand(
         console.log(`     Model: ${C.val(state.currentModel)}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to resume session:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to resume session: " + msg)}`);
       }
       console.log();
       return true;
@@ -873,7 +873,7 @@ export async function handleSlashCommand(
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  ${C.err("❌ Failed to retrieve history:")} ${msg}`);
+        console.log(`  ${C.err("❌ Failed to retrieve history: " + msg)}`);
       }
       console.log();
       return true;
@@ -1884,7 +1884,7 @@ export async function handleSlashCommand(
                 auditAbortCleanup();
                 spinner.stop();
                 const errObj = err as Error;
-                console.log(`  ${C.err("❌ Audit failed:")} ${errObj.message}`);
+                console.log(`  ${C.err("❌ Audit failed: " + errObj.message)}`);
                 // Always log the full stack to stderr for tracing.
                 console.error("[audit-trace] Full error:");
                 console.error(errObj.stack ?? errObj);
@@ -2237,7 +2237,7 @@ export async function handleSlashCommand(
         const { formatExports } = await import("./format-exports.js");
         const info = loadModule(moduleArg);
         if (!info) {
-          console.log(`  ${C.err("❌ Module not found:")} ${moduleArg}`);
+          console.log(`  ${C.err("❌ Module not found: " + moduleArg)}`);
           console.log();
           return true;
         }
@@ -2275,13 +2275,13 @@ export async function handleSlashCommand(
           await import("./module-store.js");
         const info = loadModule(moduleArg);
         if (!info) {
-          console.log(`  ${C.err("❌ Module not found:")} ${moduleArg}`);
+          console.log(`  ${C.err("❌ Module not found: " + moduleArg)}`);
           console.log();
           return true;
         }
         if (info.author === "system") {
           console.log(
-            `  ${C.err("❌ Cannot delete system module:")} ${moduleArg}`,
+            `  ${C.err("❌ Cannot delete system module: " + moduleArg)}`,
           );
           console.log();
           return true;
@@ -2490,7 +2490,7 @@ export async function handleSlashCommand(
                 console.log();
                 console.log(`  ${C.err("⚠️  Audit Warnings:")}`);
                 for (const w of warnings) {
-                  console.log(`    ${C.err("•")} ${w}`);
+                  console.log(`    ${C.err("• " + w)}`);
                 }
               }
 

--- a/src/agent/slash-commands.ts
+++ b/src/agent/slash-commands.ts
@@ -879,8 +879,9 @@ export async function handleSlashCommand(
 
     case "/open": {
       // Open a produced file by its reference number
-      const fileNum = parseInt(parts[1] ?? "", 10);
-      if (!parts[1] || !Number.isFinite(fileNum) || fileNum < 1) {
+      const rawNum = parts[1] ?? "";
+      const fileNum = /^\d+$/.test(rawNum) ? parseInt(rawNum, 10) : NaN;
+      if (!rawNum || !Number.isFinite(fileNum) || fileNum < 1) {
         console.log(
           `  ${C.err("Usage: /open <n>")} — open a produced file by number.`,
         );
@@ -896,8 +897,9 @@ export async function handleSlashCommand(
         console.log();
         return true;
       }
-      // Use xdg-open on Linux, open on macOS, cmd.exe /c start on WSL
-      const { execSync } = await import("child_process");
+      // Open file using platform-appropriate command.
+      // Use spawnSync with argv arrays to avoid shell injection.
+      const { spawnSync, execSync } = await import("child_process");
       try {
         // Detect WSL — convert to Windows path and use cmd.exe /c start
         const isWSL = existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
@@ -905,11 +907,13 @@ export async function handleSlashCommand(
           const winPath = execSync(`wslpath -w "${file.absPath}"`, {
             encoding: "utf-8",
           }).trim();
-          execSync(`cmd.exe /c start '' '${winPath}'`, { stdio: "ignore" });
+          spawnSync("cmd.exe", ["/c", "start", "", winPath], {
+            stdio: "ignore",
+          });
         } else if (process.platform === "darwin") {
-          execSync(`open "${file.absPath}"`, { stdio: "ignore" });
+          spawnSync("open", [file.absPath], { stdio: "ignore" });
         } else {
-          execSync(`xdg-open "${file.absPath}"`, { stdio: "ignore" });
+          spawnSync("xdg-open", [file.absPath], { stdio: "ignore" });
         }
         console.log(`  ${C.ok("✅")} Opened [${fileNum}] ${file.label}`);
       } catch (err) {

--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -116,6 +116,12 @@ export interface AgentState {
   /** Flag: session needs rebuild (buffer sizes changed, model switch). */
   sessionNeedsRebuild: boolean;
 
+  /**
+   * Files produced during this session, tracked for `/files` listing
+   * and `/open <n>` command. Each entry has a 1-based index.
+   */
+  producedFiles: Array<{ index: number; absPath: string; label: string }>;
+
   /** The Copilot client — spawns the CLI server process. */
   copilotClient: CopilotClient | null;
 
@@ -304,11 +310,12 @@ export function createAgentState(
     scratchOverride: null,
     reasoningEffort: null,
     verboseOutput: cli.verbose,
-    markdownEnabled: cli.markdown ?? false,
+    markdownEnabled: cli.markdown ?? true,
     auditReasoningEffort: null,
 
     // Session management
     sessionNeedsRebuild: false,
+    producedFiles: [],
     copilotClient: null,
     activeSession: null,
     cachedModels: null,

--- a/src/agent/state.ts
+++ b/src/agent/state.ts
@@ -95,6 +95,14 @@ export interface AgentState {
   verboseOutput: boolean;
 
   /**
+   * Markdown rendering mode. When true, LLM output is buffered
+   * (not streamed character-by-character) and rendered through
+   * marked-terminal for proper headings, code blocks, lists, etc.
+   * Toggled via `/markdown` command or `--markdown` CLI flag.
+   */
+  markdownEnabled: boolean;
+
+  /**
    * Reasoning effort level for audit sessions, or null → "medium".
    * Minimum is "medium" — audits should never skimp on thinking.
    * Changed via `/reasoning audit <low|medium|high|xhigh>`.
@@ -296,6 +304,7 @@ export function createAgentState(
     scratchOverride: null,
     reasoningEffort: null,
     verboseOutput: cli.verbose,
+    markdownEnabled: cli.markdown ?? false,
     auditReasoningEffort: null,
 
     // Session management

--- a/src/agent/system-message.ts
+++ b/src/agent/system-message.ts
@@ -21,6 +21,8 @@ export interface SystemMessageParams {
   outputKb: number;
   /** Whether MCP servers are configured (controls MCP hint in prompt). */
   mcpConfigured?: boolean;
+  /** Whether markdown rendering is enabled. */
+  markdownEnabled?: boolean;
 }
 
 /** Bytes per kilobyte — used for buffer size calculations. */
@@ -178,7 +180,8 @@ RESOURCE LIMITS (call configure_sandbox to increase if you hit them):
   Heap: \${HEAP_MB}MB | Scratch: \${SCRATCH_MB}MB
   Input: \${INPUT_KB}KB | Output: \${OUTPUT_KB}KB
 
-OUTPUT: Plain terminal — no markdown rendering. Tool results auto-display — don't repeat them.`;
+OUTPUT: \${OUTPUT_MODE} Tool results auto-display — don't repeat them.
+\${FILE_LINK_INSTRUCTION}`;
 
 /**
  * Build the system message with current effective resource limits.
@@ -219,5 +222,23 @@ export function buildSystemMessage(params: SystemMessageParams): string {
     .replace("${INPUT_BYTES}", String(inputBytes))
     .replace("${OUTPUT_KB}", String(params.outputKb))
     .replace("${OUTPUT_BYTES}", String(outputBytes))
-    .replace("${MCP_SECTION}", mcpSection);
+    .replace("${MCP_SECTION}", mcpSection)
+    .replace(
+      "${OUTPUT_MODE}",
+      params.markdownEnabled
+        ? "Markdown rendering is enabled — format responses with headings, lists, tables, and code blocks."
+        : "Plain terminal — no markdown rendering.",
+    )
+    .replace(
+      "${FILE_LINK_INSTRUCTION}",
+      params.markdownEnabled
+        ? [
+            "FILE REFERENCES: When summarising produced files, use [[file:path]] markers",
+            "so the terminal can make them clickable. Example:",
+            "  Created [[file:report.md]] and [[file:charts/sales.pdf]]",
+            "Use the EXACT relative path passed to write_output or returned by the handler.",
+            "Always list produced files at the end of your response using this format.",
+          ].join("\n")
+        : "",
+    );
 }


### PR DESCRIPTION
This pull request adds support for terminal markdown rendering of LLM output, improves file link handling, and enhances CLI and command features. The main improvements include integrating the `marked` and `marked-terminal` libraries to render markdown as ANSI-formatted output, introducing new CLI flags and commands for markdown and file management, and refining tool execution feedback. These changes significantly improve the readability and usability of LLM responses in the terminal.

**Markdown Rendering and CLI Enhancements:**

- Added `marked` and `marked-terminal` dependencies and integrated a new `markdown-renderer.ts` module to render LLM markdown output as ANSI-formatted terminal output, improving readability for structured responses. Also included a heuristic to detect markdown content and a post-processor to convert file references into clickable links. 
- Introduced new CLI flags (`--markdown`, `--no-markdown`, `--md`, `--no-md`) to toggle markdown rendering, with the feature enabled by default. Updated CLI config and help text accordingly. 
- Added a `/markdown` command to toggle markdown rendering at runtime, with detailed help text explaining the effects and defaults. 

**File Link and Session File Management:**

- Implemented a post-processor to convert `[[file:path]]` markers in LLM output into clickable OSC 8 terminal hyperlinks and registered file references for session management. 
- Added `/files` and `/open` slash commands to list and open files produced during the session, with corresponding help entries. 

**Tool Execution and Output Improvements:**

- Improved tool execution feedback: tool names are now shown explicitly, and for sandbox tools (`execute_javascript`, `execute_bash`), results are rendered as markdown if enabled, or dimmed otherwise. Large JSON outputs are wrapped in code blocks for better formatting. (`src/agent/event-handler.ts` 

**Other Notable Changes:**

- Added terminal hyperlink and file path formatting utilities to the ANSI helper (`src/agent/ansi.ts` 
- Added a utility to format configuration summaries as markdown tables for improved display in markdown mode. (`src/agent/slash-commands.ts`

**Build and Bash Interpreter Updates:**

- Added a stub for `node:module` to support `createRequire()` in the bash interpreter sandbox, and updated the bash bundle build process and metadata. 
- Improved error handling in the bash bundle build script to fail hard in CI if the build fails, preventing stale bundles. 