### PR TITLE
docs: add Quick Install section near top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ It is built for useful, bounded work: data analysis, document generation, API wo
 >
 > **Platform note:** HyperAgent requires hardware virtualization: Linux with KVM, Azure Linux with MSHV, Windows with WHP, or WSL2 with KVM. It does not currently run on macOS [because of this Hyperlight issue](https://github.com/hyperlight-dev/hyperlight/issues/45).
 
+## Quick Install
+
+```bash
+# Authenticate with GitHub (Copilot access required)
+gh auth login
+
+# Install and run
+npm install -g @hyperlight-dev/hyperagent
+hyperagent
+```
+
+Requires Node.js 22+ and hardware virtualization (Linux/KVM, Windows/WHP, Azure Linux/MSHV, or WSL2/KVM). For Docker, building from source, and full prerequisites, see [Install and Run](#install-and-run) below.
+
 ## Why HyperAgent?
 
 Most agent CLIs are powerful because they can touch your machine directly: shell commands, file edits, network calls, local tools, credentials, and long-lived process state. That is useful, but it also means a bad instruction, hallucinated command, or prompt-injected webpage can become real host activity very quickly.
@@ -121,14 +134,14 @@ User prompt
 
 The sandbox has no direct filesystem, network, shell, or process access. Capabilities are added deliberately:
 
-| Capability       | How it is exposed                                                |
-| ---------------- | ---------------------------------------------------------------- |
-| Files            | `fs-read` and `fs-write` plugins with path jails                 |
-| HTTP             | `fetch` plugin with domain allowlists and SSRF checks            |
+| Capability       | How it is exposed                                                         |
+| ---------------- | ------------------------------------------------------------------------- |
+| Files            | `fs-read` and `fs-write` plugins with path jails                          |
+| HTTP             | `fetch` plugin with domain allowlists and SSRF checks                     |
 | Bash commands    | `execute_bash` — sandboxed pure-JS interpreter (ls, grep, jq, curl, etc.) |
-| Reusable code    | `ha:*` system and user modules                                   |
-| External systems | MCP servers exposed as typed `host:mcp-*` modules                |
-| Bigger jobs      | Profiles that raise limits; profile tools can enable plugin sets |
+| Reusable code    | `ha:*` system and user modules                                            |
+| External systems | MCP servers exposed as typed `host:mcp-*` modules                         |
+| Bigger jobs      | Profiles that raise limits; profile tools can enable plugin sets          |
 
 ## Built-In Modules
 


### PR DESCRIPTION
## Summary

Adds a `## Quick Install` block immediately after the warning/platform callouts so new readers see the npm one-liner within the first screen, instead of having to scroll past `Why HyperAgent?`, `What Can You Do With HyperAgent?`, `Example Prompts`, `How It Works`, `Built-In Modules`, `Skills and Profiles`, `MCP Servers`, and `Security Model` before reaching `Install and Run`.

## What's in the section

```bash
gh auth login                              # auth (Copilot access required)
npm install -g @hyperlight-dev/hyperagent  # install
hyperagent                                 # run
```

Followed by a one-line note on platform requirements (Node.js 22+, KVM/WHP/MSHV/WSL2) and a forward link to the full `Install and Run` section for Docker, source builds, and prerequisites.

## Notes

- No content removed — the detailed `Install and Run` section (Docker, source builds, prerequisites, npm subsection, etc.) remains intact for users who need it.
- Prettier also realigned the capability table dividers in `How It Works` (pre-existing alignment drift from when the `execute_bash` row landed) — purely formatting, no content change. Visible in the diff but not behaviour-changing.

## Validation

- `npx prettier --check README.md` — clean
- Single commit, GPG-signed + DCO sign-off
- Based on `main@5a66988` (just-released v0.6.0)