### PR TITLE
fix(mcp): improve read-only classification and approval prompt

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1012,6 +1012,8 @@ const mcpWriteSafetyGate: WriteSafetyGate = async (
     ? C.err("⚠️  MCP DESTRUCTIVE operation")
     : C.warn("⚠️  MCP write operation");
 
+  spinner.stop();
+
   console.log();
   console.log(`  ${label}: ${C.label(serverName)}.${C.label(toolName)}`);
   if (argSummary) {

--- a/src/agent/mcp/plugin-adapter.ts
+++ b/src/agent/mcp/plugin-adapter.ts
@@ -98,7 +98,7 @@ export function createMCPPluginAdapter(
           // Write-safety gate: check tools that are not known or inferred
           // read-only. The guest VM is paused during this check, so it is
           // safe to prompt the user.
-          if (gate && !isReadOnlyMCPTool(tool)) {
+          if (gate && !isReadOnlyMCPTool(tool, toolArgs)) {
             const allowed = await gate(
               conn.name,
               tool.name,

--- a/src/agent/mcp/tool-utils.ts
+++ b/src/agent/mcp/tool-utils.ts
@@ -127,15 +127,50 @@ export function selectMCPTools(
   };
 }
 
-export function isReadOnlyMCPTool(tool: MCPToolSchema): boolean {
+export function isReadOnlyMCPTool(
+  tool: MCPToolSchema,
+  args?: Record<string, unknown>,
+): boolean {
   if (tool.annotations?.readOnlyHint === true) return true;
   if (tool.annotations?.destructiveHint === true) return false;
+
+  const operationHint = inferReadOnlyFromArgs(args);
+  if (operationHint !== null) return operationHint;
 
   const name = normaliseToolName(tool.name);
   if (WRITE_TOOL_PREFIXES.some((prefix) => name.startsWith(prefix))) {
     return false;
   }
   return READ_ONLY_TOOL_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+function inferReadOnlyFromArgs(
+  args: Record<string, unknown> | undefined,
+): boolean | null {
+  if (!args || typeof args !== "object") return null;
+
+  const candidates = [
+    args.operation,
+    args.action,
+    args.command,
+    args.method,
+    args.kind,
+    args.type,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+
+    const value = normaliseToolName(candidate);
+    if (WRITE_TOOL_PREFIXES.some((prefix) => value.startsWith(prefix))) {
+      return false;
+    }
+    if (READ_ONLY_TOOL_PREFIXES.some((prefix) => value.startsWith(prefix))) {
+      return true;
+    }
+  }
+
+  return null;
 }
 
 export function getMCPToolSafety(tool: MCPToolSchema): MCPToolInfo["safety"] {

--- a/src/code-validator/guest/Cargo.lock
+++ b/src/code-validator/guest/Cargo.lock
@@ -183,7 +183,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672b945a3e4f4f40bfd4cd5ee07df9e796a42254ce7cd6d2599ad969244c44a"
 dependencies = [
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -700,7 +700,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "spin",
+ "spin 0.12.0",
 ]
 
 [[package]]
@@ -711,7 +711,7 @@ dependencies = [
  "anyhow",
  "flatbuffers",
  "log",
- "spin",
+ "spin 0.10.0",
  "thiserror",
  "tracing",
  "tracing-core",
@@ -745,7 +745,7 @@ dependencies = [
  "hyperlight-guest-tracing",
  "linkme",
  "log",
- "spin",
+ "spin 0.10.0",
  "tracing",
 ]
 
@@ -766,7 +766,7 @@ version = "0.13.1"
 source = "git+https://github.com/simongdavies/hyperlight?branch=update-surrogate#5f1912b4ce8a8d83e6ce63425d766bd50f511ef8"
 dependencies = [
  "hyperlight-common",
- "spin",
+ "spin 0.10.0",
  "tracing",
  "tracing-core",
 ]
@@ -1535,6 +1535,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 dependencies = [
  "lock_api",
 ]

--- a/src/code-validator/guest/runtime/Cargo.toml
+++ b/src/code-validator/guest/runtime/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1", default-features = false, features = ["derive", "alloc"
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 regex-automata = { version = "0.4", default-features = false, features = ["alloc", "meta", "nfa-pikevm"] }
 nom = { version = "8.0", default-features = false, features = ["alloc"] }
-spin = "0.10"
+spin = "0.12"
 rquickjs = { version = "0.11", default-features = false, features = ["bindgen", "loader"] }
 hashbrown = "0.17"
 sha2 = { version = "0.11", default-features = false }

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1050,6 +1050,23 @@ describe("MCP tool utility helpers", () => {
     expect(isReadOnlyMCPTool(tools[1])).toBe(true);
     expect(isReadOnlyMCPTool(tools[2])).toBe(false);
   });
+
+  it("treats Power BI-style list operations as read-only from the request payload", () => {
+    const powerBiTool = {
+      name: "connection_operations",
+      originalName: "connection_operations",
+      description: "Connect to Power BI models",
+      inputSchema: {
+        type: "object",
+        properties: {
+          operation: { type: "string" },
+        },
+      },
+    } as never;
+
+    expect(isReadOnlyMCPTool(powerBiTool, { operation: "ListLocalInstances" })).toBe(true);
+    expect(isReadOnlyMCPTool(powerBiTool, { operation: "CreateModel" })).toBe(false);
+  });
 });
 
 describe("normaliseToolResult", () => {


### PR DESCRIPTION
This PR isolates the MCP safety fix onto its own branch.

- use request payload operation/action hints when classifying MCP tools as read-only
- pass tool arguments through the safety gate to avoid false write approvals
- stop the approval spinner before showing the prompt so the prompt remains visible
- add a Power BI-style regression test for generic list operations