### PR TITLE
ci: lint Windows-only Rust with a native Windows clippy job

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -161,6 +161,34 @@ jobs:
           path: dist/
           retention-days: 7
 
+  # Lint Windows-only Rust code paths (cfg(target_os = "windows") / WHP) that
+  # the Linux lint-and-test job never scans. Runs the analysis-guest clippy
+  # natively on the Windows 1ES pool so cfg(windows) branches in the host crate
+  # are checked under -D warnings.
+  clippy-windows:
+    name: Clippy (Windows)
+    needs: [docs-pr]
+    if: needs.docs-pr.outputs.docs-only != 'true'
+    runs-on: [self-hosted, Windows, X64, "1ES.Pool=hld-win2025-amd", "JobId=clippy-windows-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+        with:
+          rust-toolchain: "1.89"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup
+        run: just setup
+
+      - name: Clippy (analysis-guest)
+        run: just lint-analysis-guest
+
   # PDF visual regression tests — run on a GitHub-hosted ubuntu-22.04 image
   # so goldens are pixel-matched against a reproducible, fork-accessible runner.
   # The update-golden.yml workflow uses the same image to regenerate baselines.
@@ -247,7 +275,7 @@ jobs:
   # Gate PR merges on all jobs passing
   ci-status:
     name: CI Status
-    needs: [docs-pr, lint-and-test, build-and-test, pdf-visual, build-docker]
+    needs: [docs-pr, lint-and-test, build-and-test, clippy-windows, pdf-visual, build-docker]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/src/code-validator/guest/host/src/sandbox.rs
+++ b/src/code-validator/guest/host/src/sandbox.rs
@@ -191,7 +191,7 @@ pub fn check_hyperlight_availability() -> Result<String> {
     #[cfg(target_os = "windows")]
     {
         // WHP is always available on Windows 10+
-        return Ok("whp".to_string());
+        Ok("whp".to_string())
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## What

Adds a **native Windows clippy CI job** so Windows-only Rust code paths get linted.

Today clippy runs **only on Linux** (the `lint-and-test` job's `just lint-all`). That means `#[cfg(target_os = "windows")]` / WHP branches in the `host` crate are never scanned, and a real `clippy -D warnings` error has been hiding there.

## Changes

- **`.github/workflows/pr-validate.yml`**  new `clippy-windows` job (name: *Clippy (Windows)*) on the `hld-win2025-amd` 1ES pool, mirroring the WHP build runner labels. It runs `just lint-analysis-guest` (`cargo fmt --check` + `cargo clippy --workspace -- -D warnings`) natively on Windows. Wired into `ci-status` so it gates merges.
- **`src/code-validator/guest/host/src/sandbox.rs`**  fixes the pre-existing `clippy::needless_return` that the new job surfaces, turning the `#[cfg(windows)]` WHP arm into a tail expression (`Ok("whp".to_string())`).

## Validation

Verified natively on `x86_64-pc-windows-msvc` that the `#[cfg(windows)]` block is correctly treated as the function's tail expression (compiles clean, returns `Ok("whp")`); the non-Windows `Err` tail is unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
