### PR TITLE
chore: add seven-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"
@@ -11,6 +13,8 @@ updates:
     directories:
       - "/src/sandbox/runtime"
       - "/src/code-validator/guest"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"
@@ -20,6 +24,8 @@ updates:
     directories:
       - "/"
       - "/src/code-validator/guest"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"


### PR DESCRIPTION
## Summary
- Add `cooldown.default-days: 7` for GitHub Actions, Cargo, and npm.
- Keep the existing daily 03:00 schedule, PR limits, and ignored dependency unchanged.
- Delay version-update PRs until releases are at least seven days old; security updates remain unaffected.

## Validation
- `git diff --check` passed.
- Commit created with `git commit -S -s`; GPG signature verified and Signed-off-by trailer present.
- `just check` was started but stopped during native runtime compilation after several minutes. The full quality gate did not complete; this change only modifies Dependabot configuration.