### PR TITLE
fix(deps): align Hyperlight 0.17 and hyperlight-js 0.4.0

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,7 @@ export CMAKE_GENERATOR := if os() == "windows" { "Ninja" } else { "" }
 # DEFAULT runtime at compile time — it can't carry our native modules. A pinned
 # release tag of the official repo is not a fork/branch. Bump together with the
 # hyperlight-js-runtime crate version.
-hyperlight-js-tag := "v0.3.3"
+hyperlight-js-tag := "v0.4.0"
 
 # Local checkout of the hyperlight-js source, cloned at hyperlight-js-tag.
 hyperlight-src    := justfile_dir() / "deps" / "hyperlight-js-src"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
     },
     "deps/js-host-api": {
       "name": "@hyperlight-dev/js-host-api",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/src/code-validator/guest/Cargo.lock
+++ b/src/code-validator/guest/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
  "bindgen",
  "clap",
  "hashbrown",
- "hyperlight-common 0.17.0",
+ "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-bin",
  "nom 8.0.0",
@@ -848,26 +848,6 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "spin 0.12.3",
-]
-
-[[package]]
-name = "hyperlight-common"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436dac5cc08da3db27de38b174a9b22498ab6443aaffd83b97f66a5d2f1d74cc"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "bytemuck",
- "bytes",
- "fixedbitset",
- "flatbuffers",
- "log",
- "smallvec",
- "spin 0.12.3",
- "thiserror",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -886,31 +866,32 @@ dependencies = [
  "smallvec",
  "spin 0.12.3",
  "thiserror",
+ "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb2e6548e2b837400a7b27a5ed6a6570c28801253e6ec80959700dd63925c40"
+checksum = "816f673f3f8ef6d5703796bf92927b85177ad1baac6f391551a88451a9e46a7e"
 dependencies = [
  "anyhow",
  "flatbuffers",
- "hyperlight-common 0.16.0",
+ "hyperlight-common",
  "serde_json",
  "tracing",
 ]
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeccde6490e76aefe2e8ca17e1a225d2da3338f020f17533b8ee0cee7cf9a11"
+checksum = "9c2d0ea739be89822992706da9dc6812ce359b654b328efd6141ba1549751907"
 dependencies = [
  "buddy_system_allocator",
  "flatbuffers",
- "hyperlight-common 0.16.0",
+ "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-macro",
  "hyperlight-guest-tracing",
@@ -923,23 +904,23 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-macro"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620ed77c5c07027c63a6a741da8a9a2462a56e660691da715c3700cb281a3d23"
+checksum = "875d03a9e4d302f29d8feb57faff937f80c6f69ec9d31b32f41c41721144e25d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b39160c2001db5c79916d946d04a601e4e1f2827e2c785d477b31e48f5e514"
+checksum = "8f43a3d5d3fa245ce0fccee8a48ad7d94ec479e0898fc8f91fd440a1d65830c6"
 dependencies = [
- "hyperlight-common 0.16.0",
+ "hyperlight-common",
  "spin 0.12.3",
  "tracing",
  "tracing-core",
@@ -947,21 +928,23 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3edc7875e70a3b5cc291a17f78cfc352e24c9a665a5a1bbdbc46ada3df43b5"
+checksum = "d85dcf5ae7a578e1b09bdeb76cc3b3ca8e6e57d6395d2f57204aec45c1bbbde9"
 dependencies = [
  "anyhow",
+ "bindgen",
  "bitflags 2.13.0",
  "blake3",
  "bytemuck",
+ "cc",
  "cfg-if",
  "cfg_aliases",
  "crossbeam-channel",
  "flatbuffers",
  "goblin",
  "hex",
- "hyperlight-common 0.16.0",
+ "hyperlight-common",
  "kvm-bindings",
  "kvm-ioctls",
  "lazy_static",
@@ -972,6 +955,7 @@ dependencies = [
  "mshv-ioctls",
  "oci-spec",
  "page_size",
+ "parking_lot",
  "rand",
  "rust-embed",
  "serde",
@@ -992,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-libc"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c258315b4c0ec4aae172c4ff31b34590559fb6699c144f779be2246672b3147"
+checksum = "108dd0e7335821a2ef0dfa375c08236c3302a117045822e2aa68c64147f8e895"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1383,6 +1367,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a224897b65b7ce38bf7b0adb569e7d77e11460d0cc3577908b263d8b5a89aa"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]

--- a/src/code-validator/guest/Cargo.toml
+++ b/src/code-validator/guest/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/anthropics/hyperagent"
 
 [workspace.dependencies]
 # Hyperlight core crates — published on crates.io, pinned to the version that
-# hyperlight-js 0.3.x builds against.
+# hyperlight-js 0.4.x builds against. Update these crates together.
 hyperlight-common = { version = "0.17.0", default-features = false }
 hyperlight-guest-bin = { version = "0.17.0" }
 hyperlight-guest = { version = "0.17.0" }

--- a/src/code-validator/guest/Cargo.toml
+++ b/src/code-validator/guest/Cargo.toml
@@ -20,9 +20,9 @@ repository = "https://github.com/anthropics/hyperagent"
 # Hyperlight core crates — published on crates.io, pinned to the version that
 # hyperlight-js 0.3.x builds against.
 hyperlight-common = { version = "0.17.0", default-features = false }
-hyperlight-guest-bin = { version = "0.16.0" }
-hyperlight-guest = { version = "0.16.0" }
-hyperlight-host = { version = "0.16.0", default-features = false, features = ["executable_heap", "kvm", "mshv3"] }
+hyperlight-guest-bin = { version = "0.17.0" }
+hyperlight-guest = { version = "0.17.0" }
+hyperlight-host = { version = "0.17.0", default-features = false, features = ["executable_heap", "kvm", "mshv3"] }
 
 [profile.dev]
 panic = "abort"

--- a/src/code-validator/guest/host/src/sandbox.rs
+++ b/src/code-validator/guest/host/src/sandbox.rs
@@ -117,7 +117,7 @@ fn call_guest_function_sync(function_name: &str, input: String) -> Result<String
     config.set_output_data_size(GUEST_OUTPUT_SIZE);
 
     // Create the guest binary from embedded bytes
-    let guest_binary = GuestBinary::Buffer(ANALYSIS_RUNTIME);
+    let guest_binary = GuestBinary::Buffer(ANALYSIS_RUNTIME.to_vec());
 
     // Create uninitialized sandbox
     let uninitialized = UninitializedSandbox::new(guest_binary, Some(config)).map_err(|e| {
@@ -152,7 +152,7 @@ fn call_guest_function_2_sync(
     config.set_input_data_size(GUEST_INPUT_SIZE);
     config.set_output_data_size(GUEST_OUTPUT_SIZE);
 
-    let guest_binary = GuestBinary::Buffer(ANALYSIS_RUNTIME);
+    let guest_binary = GuestBinary::Buffer(ANALYSIS_RUNTIME.to_vec());
 
     let uninitialized = UninitializedSandbox::new(guest_binary, Some(config)).map_err(|e| {
         Error::new(

--- a/src/sandbox/runtime/Cargo.lock
+++ b/src/sandbox/runtime/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436dac5cc08da3db27de38b174a9b22498ab6443aaffd83b97f66a5d2f1d74cc"
+checksum = "3ad5576d6ef947dc2822c2f5038ddff8325c158ddef4cbabf9d0b125294cdb0f"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb2e6548e2b837400a7b27a5ed6a6570c28801253e6ec80959700dd63925c40"
+checksum = "816f673f3f8ef6d5703796bf92927b85177ad1baac6f391551a88451a9e46a7e"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeccde6490e76aefe2e8ca17e1a225d2da3338f020f17533b8ee0cee7cf9a11"
+checksum = "9c2d0ea739be89822992706da9dc6812ce359b654b328efd6141ba1549751907"
 dependencies = [
  "buddy_system_allocator",
  "flatbuffers",
@@ -543,21 +543,21 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-macro"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620ed77c5c07027c63a6a741da8a9a2462a56e660691da715c3700cb281a3d23"
+checksum = "875d03a9e4d302f29d8feb57faff937f80c6f69ec9d31b32f41c41721144e25d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b39160c2001db5c79916d946d04a601e4e1f2827e2c785d477b31e48f5e514"
+checksum = "8f43a3d5d3fa245ce0fccee8a48ad7d94ec479e0898fc8f91fd440a1d65830c6"
 dependencies = [
  "hyperlight-common",
  "spin 0.12.1",
@@ -567,15 +567,15 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js-common"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2ca4a9f3afe879c8fcdf7802672f0dbdc37d1301f268b263e08c560f42530b"
+checksum = "27f04e014d3347d65bb085d089c53c01be5181242a67271574da7804a28e8a21"
 
 [[package]]
 name = "hyperlight-js-runtime"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c020ac9e87be141f63e2237437707c634d0850a1b2d5499bbcafc053cd47345"
+checksum = "d3c397d0163456d3099a71d15994a4490abc48ce4c95fe5b805a5fa6489330ba"
 dependencies = [
  "anyhow",
  "base64",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-libc"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c258315b4c0ec4aae172c4ff31b34590559fb6699c144f779be2246672b3147"
+checksum = "108dd0e7335821a2ef0dfa375c08236c3302a117045822e2aa68c64147f8e895"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -679,7 +679,7 @@ checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -890,7 +890,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -957,7 +957,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1057,6 +1057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,7 +1084,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1126,7 +1137,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src/sandbox/runtime/Cargo.toml
+++ b/src/sandbox/runtime/Cargo.toml
@@ -13,7 +13,7 @@ name = "hyperagent-runtime"
 path = "src/main.rs"
 
 [dependencies]
-hyperlight-js-runtime = { version = "0.3.3" }
+hyperlight-js-runtime = { version = "0.4.0" }
 native-deflate = { path = "modules/native-deflate" }
 native-image = { path = "modules/native-image" }
 native-html = { path = "modules/native-html" }


### PR DESCRIPTION
## Summary

- Combine the Hyperlight 0.17.0 dependency updates from #337, #338 and #339 in the analysis workspace and regenerate its lockfile together, eliminating mixed 0.16/0.17 guest dependencies.
- Adapt both embedded guest binary constructors to `GuestBinary::Buffer(Vec<u8>)`, required by hyperlight-host 0.17.0.
- Update the sandbox runtime to hyperlight-js-runtime 0.4.0 (superseding #345) and the source-built host addon to the matching `v0.4.0` release tag in `Justfile`.
- Regenerate the sandbox Cargo lockfile, update the npm addon lock metadata, and correct the analysis workspace comment to describe the hyperlight-js 0.4.x / Hyperlight 0.17 alignment.

## CI investigation and validation

#338 and #339 fail with guest-function trait mismatches from mixed Hyperlight versions. #337 fails at both guest buffer constructors with `expected Vec<u8>, found &[u8]`.

**All CI checks pass on final commit 44436ba**, including the hyperlight-js 0.4.0 update: [Validate Pull Request run](https://github.com/hyperlight-dev/hyperagent/actions/runs/34148292012). This covers Linux KVM and MSHV debug/release, Windows WHP debug/release, lint and tests, Windows Clippy, PDF visual regression, and Docker build. CodeQL and DCO also pass.

Local Rust formatting and version/lock metadata consistency checks pass. Local `just build` and `just check` are blocked by a Windows linker output-path failure building Hyperlight's surrogate. Automatic npm lockfile regeneration also encounters an unavailable pre-existing `@napi-rs/cli@^3.9.0` dependency on the local registry mirror; only the local addon version metadata was adjusted, and its metadata was compared with the pinned release manifest.

Future Hyperlight Dependabot version-update grouping is proposed separately in #350.

Closes #337
Closes #338
Closes #339
Closes #345