### PR TITLE
chore(deps): group Hyperlight Cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directories:
       - "/src/sandbox/runtime"
       - "/src/code-validator/guest"
+    groups:
+      hyperlight:
+        patterns:
+          - "hyperlight-*"
     cooldown:
       default-days: 7
     schedule:


### PR DESCRIPTION
## Summary

Add a `hyperlight` group matching `hyperlight-*` to the existing multi-directory Cargo entry in `.github/dependabot.yml`. Eligible version updates for matching crates are grouped into a single PR across `/src/sandbox/runtime` and `/src/code-validator/guest`.

- Uses the default `applies-to: version-updates` behavior, with no major/minor/patch restriction.
- Preserves daily 03:00 schedules, seven-day cooldowns, PR limits, and all non-Hyperlight configuration. Nonmatching Cargo dependencies remain ungrouped.
- Leaves security updates unchanged; this does not combine security and version updates in one PR.

This config-only follow-up is separate from the dependency changes in #349.

## Validation

Parsed YAML with PyYAML and compared it structurally with the baseline, confirming the new Cargo group is the only configuration change. `git diff --check` passed. No native build is needed for this config-only change.

Configuration follows the [official Dependabot grouping reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--).