### PR TITLE
chore(deps): group NAPI Cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
       hyperlight:
         patterns:
           - "hyperlight-*"
+      napi:
+        patterns:
+          - "napi"
+          - "napi-*"
     cooldown:
       default-days: 7
     schedule:


### PR DESCRIPTION
## Summary

Group `napi` and `napi-*` Cargo dependency updates into a single Dependabot PR, following the existing `hyperlight-*` grouping. The group applies across both configured Cargo directories; schedules, cooldowns, and existing groups are unchanged.

## Motivation

PR #313 updated `napi-derive` and `napi-derive-backend` while leaving `napi` at 3.12.0. The newer generated bindings require `NativeBorrowBarrier` and `NativeBorrowScope` from a newer runtime, causing compilation failures across CI. Updating the runtime and macro crates together avoids that split-update mismatch.

The immediate lockfile fix is being handled separately in #313; this PR changes only `.github/dependabot.yml`.

## Validation

- Parsed the YAML and confirmed both the new NAPI patterns and existing Hyperlight group.
- `git diff --check` passed.
- Attempted full `just check`; native prerequisites fail on Windows with linker error LNK1104 while creating the `hyperlight_surrogate` build-script executable under the long worktree target path. Stopped the remaining build after the prerequisite failures; the full quality gate could not complete locally.